### PR TITLE
fix zsh-bash portablility

### DIFF
--- a/ENV_SETUP
+++ b/ENV_SETUP
@@ -60,9 +60,9 @@ BINPATH=$INSTALL_DIR/bin/
 LIBPATH=$INSTALL_DIR/lib/
 
 if [[ -d "$BINPATH" && -d "$LIBPATH" ]]; then
-    export PATH+=:$(realpath $BINPATH)
-    export PYTHONPATH+=:$(realpath $LIBPATH)
-    export PYTHONPATH+=:$(realpath $BINPATH)
+    export PATH="${PATH:+$PATH:}$(realpath $BINPATH)"
+    export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}$(realpath $LIBPATH)"
+    export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}$(realpath $BINPATH)"
 else
     err "tt-npe install directory not found at '$INSTALL_DIR'"
     err "Please run 'cd $ROOT && ./build-npe.sh' first, then source ENV_SETUP again"


### PR DESCRIPTION
Source ENV_SETUP fails with this on ZSH:

this workaround works on both bash and zsh

```
ENV_SETUP:export:63: not valid in this context: PATH+
```