### PR TITLE
Add deepwiki badge for tt-npe

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://github.com/bgrady-tt/tt-npe/actions/workflows/build_and_test_ubuntu.yml/badge.svg)](https://github.com/bgrady-tt/tt-npe/actions/workflows/build_and_test_ubuntu.yml)
 [![License Check](https://github.com/bgrady-tt/tt-npe/actions/workflows/spdx.yml/badge.svg)](https://github.com/bgrady-tt/tt-npe/actions/workflows/spdx.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tenstorrent/tt-npe)
 
 *Devices Supported*: `wormhole_b0`
 


### PR DESCRIPTION
TT-NPE has a deepwiki page but nothing displayed to indicate that. This pull request adds a deepwiki badge so people know that deepwiki pages are available.