### PR TITLE
Fix DRAM controller lookup for multichip systems

### DIFF
--- a/tt_npe/cpp/include/device_models/blackhole.hpp
+++ b/tt_npe/cpp/include/device_models/blackhole.hpp
@@ -294,8 +294,9 @@ class BlackholeDeviceModel : public npeDeviceModel {
     CoreType getCoreType(const Coord &c) const override { return coord_to_core_type(c.row, c.col); }
 
     uint32_t getDramControllerIDForCore(const Coord &c) const override {
-        TT_ASSERT(dram_coord_to_controller_map.contains(c), "Could not find dram controller for coord {{ {}, {} }}", c.row, c.col);
-        return dram_coord_to_controller_map.at(c);
+        Coord local{_device_id, c.row, c.col};
+        TT_ASSERT(dram_coord_to_controller_map.contains(local), "Could not find dram controller for coord {{ {}, {} }}", c.row, c.col);
+        return dram_coord_to_controller_map.at(local);
     }
 
     BytesPerCycle getSrcInjectionRateByCoreType(CoreType core_type) const {

--- a/tt_npe/cpp/include/device_models/wormhole_b0.hpp
+++ b/tt_npe/cpp/include/device_models/wormhole_b0.hpp
@@ -282,8 +282,9 @@ class WormholeB0DeviceModel : public npeDeviceModel {
     CoreType getCoreType(const Coord &c) const override { return coord_to_core_type(c.row, c.col); }
 
     uint32_t getDramControllerIDForCore(const Coord &c) const override {
-        TT_ASSERT(dram_coord_to_controller_map.contains(c), "Could not find dram controller for coord {{ {}, {} }}", c.row, c.col);
-        return dram_coord_to_controller_map.at(c);
+        Coord local{_device_id, c.row, c.col};
+        TT_ASSERT(dram_coord_to_controller_map.contains(local), "Could not find dram controller for coord {{ {}, {} }}", c.row, c.col);
+        return dram_coord_to_controller_map.at(local);
     }
 
     BytesPerCycle getSrcInjectionRateByCoreType(CoreType core_type) const {


### PR DESCRIPTION
## Issue
I was hitting this error when running tracy with `--collect-noc-traces` on a T3K:
```
E: tt-npe exited unsuccessfully with error UNDEF - TT_ASSERT @.../tt_npe/cpp/include/device_models/wormhole_b0.hpp:285: dram_coord_to_controller_map.contains(c)
info:
Could not find dram controller for coord { 11, 0 }
```

## Root cause
`getDramControllerIDForCore` on both `WormholeB0DeviceModel` and `BlackholeDeviceModel` looks up `dram_coord_to_controller_map` with the caller's `Coord` directly. The map is keyed by `{_device_id=0, row, col}` and `Coord::operator==` compares `device_id`, so any lookup from a multichip wrapper (T3K, N300, TG, GALAXY, P300, P150_X8, BLACKHOLE_GALAXY) with `device_id >= 1` fails the assert.

## Fix
Normalize the incoming `Coord` to the model's local `_device_id` before the lookup — matching how `getCoreType`, `getNIUID`, and the routing helpers in the same files already slice device_id.