### PR TITLE
Model per-DRAM-controller bandwidth congestion (opt-in) + DRAM hotspot reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,88 @@ visualization tool, but it could be used for ad-hoc analysis as well.
 
 See `tt_npe.py --help` for more information about available options.
 
+### DRAM Controller Congestion Modelling
+
+By default tt-npe derates bandwidth per *link* and per *NIU* only. On both Wormhole and
+Blackhole **three DRAM NIU coordinates share a single DRAM controller**, and NOC0 and NOC1
+traffic to the same coordinate is tracked separately again, so a controller can be several
+times oversubscribed while every individual NIU it sits behind still looks unsaturated.
+
+The optional per-DRAM-controller model closes that gap. It is controlled by two options:
+
+| Option | Config field | Default |
+| --- | --- | --- |
+| `--dram-controller-model {off,observe,enforce}` | `dram_controller_model` | `off` |
+| `--dram-controller-capacity-scale <float>` | `dram_controller_capacity_scale` | `1.0` |
+
+- **`off`** — no demand grid is allocated and every code path added by this feature is
+  skipped. Predictions are bit-identical to a build without the feature. **This is the
+  default**; see the caveat below.
+- **`observe`** — per-controller demand is accumulated and reported, but never derates
+  bandwidth. Cycle predictions are therefore *identical* to `off`. Use this to find out
+  whether a workload is DRAM-controller-bound without changing any published number.
+- **`enforce`** — demand is accumulated, reported, **and** derates the bandwidth of
+  transfers sharing an oversubscribed controller, so `estimated_cycles` grows.
+
+The controller derate composes with the existing link and NIU derates using `min()`, never a
+product: link, NIU and controller are *nested* resources, so the tightest one binds and no
+term is double-counted.
+
+#### Why the default is `off`
+
+The per-controller capacity this model derates against has **not** been validated against
+silicon. On Blackhole tt-npe derives 40.0 B/cyc/controller from its DRAM injection and
+absorption rates, while the datasheet figure of 512 GB/s over 8 controllers at 1.35 GHz
+implies 47.4 B/cyc — roughly a 19% disagreement. Which constant is right (and whether a
+single constant is right at all, given read/write asymmetry and refresh overhead) is an open
+question, so enabling the derate by default would silently move every existing prediction on
+the strength of an unvalidated number.
+
+`dram_controller_capacity_scale` is the calibration knob for that band: it scales the
+capacity used by the congestion model **only**, so sweeping it can never perturb the
+post-hoc `dram_bw_util`, `dram_bw_util_sim` or `dram_bw_util_per_controller` numbers that
+tt-npe already reports. Setting it high enough that the controller can never bind makes
+`enforce` collapse back onto `off`, which is a useful way to confirm that a cycle-count
+change really is attributable to the controller term.
+
+#### Reading DRAM hotspot output
+
+With the model enabled, the stats summary gains two lines:
+
+```
+  DRAM ctrl demand: peak 300.0%  avg  37.5%
+     DRAM hotspots: d0c0 peak=300.0% mean=300.0% sat=100%
+
+    max NIU  demand:   0.5%
+```
+
+(The `max NIU demand` line is included to show what the model buys you: three concurrent
+reads pin controller 0 at 300% of its bandwidth while no individual NIU looks remotely
+busy. `avg` is taken over *all* controllers, so one hot controller out of eight reads as
+`300 / 8 = 37.5%`.)
+
+A hotspot reads as `d<device>c<controller>`:
+
+- **`peak`** — the highest single-timestep demand on that controller, as a percentage of
+  controller bandwidth. `300%` means three NIUs each asking for the controller's full rate.
+- **`mean`** — demand averaged over all simulated timesteps, same units. A high peak with a
+  low mean is a transient; a high mean is a sustained bottleneck.
+- **`sat`** — the fraction of timesteps in which demand met or exceeded capacity.
+
+Demand is *offered* demand, sampled from un-derated bandwidths at the top of each timestep —
+the same convention as the existing link and NIU demand numbers. It therefore reads the same
+under `observe` and `enforce`; what changes between the two modes is `estimated_cycles`.
+
+The same values are available programmatically on each `deviceStats` object:
+`overall_max_dram_controller_demand`, `overall_avg_dram_controller_demand`,
+`dram_controller_peak_demand`, `dram_controller_mean_demand`,
+`dram_controller_saturated_frac`, `dram_controller_capacity`, plus the accessors
+`getDRAMHotspots(threshold_pct=90.0)`, `getDRAMHotspotStr()` and `isDRAMBound()`. All of them
+are zero/empty when the model is `off`. Map keys are the DRAM controller ID for a
+single-device `deviceStats`, and the flattened `device_id * num_controllers + controller_id`
+slot for the mesh-level entry; `getDRAMHotspots()` decomposes them back into `device_id` and
+`controller_id` for you.
+
 ### Constructing Workloads Programmatically
 
 tt-npe workloads are comprimised as collections of `Transfers`. Each `Transfer`

--- a/tt_npe/cpp/include/device_models/blackhole.hpp
+++ b/tt_npe/cpp/include/device_models/blackhole.hpp
@@ -34,6 +34,16 @@ class BlackholeDeviceModel : public npeDeviceModel {
         else {
             NUM_DRAM_CONTROLLERS = 8;
         }
+
+        // Derive the *grid sizing* controller count from the coordinate map rather than from
+        // NUM_DRAM_CONTROLLERS. Under SINGLE_BANK_HARVESTING the latter is 7 while
+        // dram_coord_to_controller_map still emits IDs 0..7; sizing off it would be an
+        // out-of-bounds write on controller 7.
+        _num_distinct_dram_controllers = 0;
+        for (const auto &[coord, controller_id] : dram_coord_to_controller_map) {
+            _num_distinct_dram_controllers =
+                std::max(_num_distinct_dram_controllers, size_t(controller_id) + 1);
+        }
     }
 
     void populateNoCLinkLookups() {
@@ -71,8 +81,15 @@ class BlackholeDeviceModel : public npeDeviceModel {
         const std::vector<PETransferID> &live_transfer_ids,
         NIUDemandGrid &niu_demand_grid,
         LinkDemandGrid &link_demand_grid,
-        LinkDemandGrid &multicast_write_link_demand_grid) const {
+        LinkDemandGrid &multicast_write_link_demand_grid,
+        DramDemandGrid &dram_demand_grid,
+        const DramCongestionParams &dram_params) const {
         Cycle cycles_per_timestep = end_timestep - start_timestep;
+
+        // DRAM controller model is fully short-circuited when the grid was never sized.
+        const bool model_dram_controllers = !dram_demand_grid.empty();
+        const float DRAM_CONTROLLER_BANDWIDTH =
+            getDRAMControllerCongestionCapacity(dram_params.capacity_scale);
 
         // assume all links have identical bandwidth
         float LINK_BANDWIDTH = getLinkBandwidth(nocLinkID());
@@ -92,6 +109,7 @@ class BlackholeDeviceModel : public npeDeviceModel {
                 multicast_write_link_demand_grid.begin(),
                 multicast_write_link_demand_grid.end(),
                 0.0f);
+            std::fill(dram_demand_grid.begin(), dram_demand_grid.end(), 0.0f);
             for (auto ltid : live_transfer_ids) {
                 auto &lt = transfers[ltid];
 
@@ -123,6 +141,25 @@ class BlackholeDeviceModel : public npeDeviceModel {
                         if (getCoreType(c) == CoreType::WORKER) {
                             nocNIUID niu_id = getNIUID(c.row, c.col, sink_niu_type);
                             niu_demand_grid[niu_id] += effective_demand;
+                        }
+                    }
+                }
+
+                // Track demand at the DRAM controller shared by several DRAM NIUs. The
+                // per-NIU grid above is keyed by (coord, nocNIUType), so the 3 DRAM NIU
+                // coords of one controller -- and NOC0 vs NOC1 traffic to the same coord --
+                // land in separate buckets and can each look unsaturated while the
+                // controller behind them is oversubscribed. This grid is the one place
+                // where that traffic is summed. Multicast is skipped: the sink loop above
+                // already restricts multicast sinks to WORKER cores.
+                if (model_dram_controllers) {
+                    if (getCoreType(lt.params.src) == CoreType::DRAM) {
+                        dram_demand_grid[getDramDemandID(lt.params.src)] += effective_demand;
+                    }
+                    if (std::holds_alternative<Coord>(lt.params.dst)) {
+                        const auto &dst = std::get<Coord>(lt.params.dst);
+                        if (getCoreType(dst) == CoreType::DRAM) {
+                            dram_demand_grid[getDramDemandID(dst)] += effective_demand;
                         }
                     }
                 }
@@ -191,8 +228,41 @@ class BlackholeDeviceModel : public npeDeviceModel {
 
                 auto min_niu_bw_derate = std::min(src_bw_derate, sink_bw_derate);
 
-                if (min_link_bw_derate < 1.0 || min_niu_bw_derate < 1.0) {
-                    float overall_bw_derate = std::min(min_link_bw_derate, min_niu_bw_derate);
+                // Derate against the shared DRAM controller. Structurally identical to the
+                // sink NIU derate above (capacity / demand).
+                //
+                // NOTE ON DOUBLE COUNTING: derates are composed with min(), never a
+                // product. min() is the correct operator for *nested* resources -- a
+                // transfer is limited by the tightest of {links on its route, its own NIU,
+                // the controller that NIU shares}. A single DRAM NIU can only demand up to
+                // its own absorption rate, which is below the controller capacity, so the
+                // controller term is inert for uncontended traffic and only binds once
+                // several NIUs of one controller are active together. Keep BOTH terms:
+                // dropping the NIU derate on DRAM coords would let a single NIU reach full
+                // controller bandwidth, which is wrong in the other direction.
+                float dram_bw_derate = 1.0f;
+                if (model_dram_controllers && dram_params.enforcing()) {
+                    if (getCoreType(lt.params.src) == CoreType::DRAM) {
+                        dram_bw_derate = std::min(
+                            dram_bw_derate,
+                            DRAM_CONTROLLER_BANDWIDTH /
+                                dram_demand_grid[getDramDemandID(lt.params.src)]);
+                    }
+                    if (std::holds_alternative<Coord>(lt.params.dst)) {
+                        const auto &dst = std::get<Coord>(lt.params.dst);
+                        if (getCoreType(dst) == CoreType::DRAM) {
+                            dram_bw_derate = std::min(
+                                dram_bw_derate,
+                                DRAM_CONTROLLER_BANDWIDTH /
+                                    dram_demand_grid[getDramDemandID(dst)]);
+                        }
+                    }
+                }
+
+                if (min_link_bw_derate < 1.0 || min_niu_bw_derate < 1.0 ||
+                    dram_bw_derate < 1.0) {
+                    float overall_bw_derate =
+                        std::min({min_link_bw_derate, min_niu_bw_derate, dram_bw_derate});
 
                     lt.curr_bandwidth *= 1.0 - (grad_fac * (1.0f - overall_bw_derate));
                 }
@@ -200,10 +270,12 @@ class BlackholeDeviceModel : public npeDeviceModel {
         }
     }
 
-    std::unique_ptr<npeDeviceState> initDeviceState() const override {
+    std::unique_ptr<npeDeviceState> initDeviceState(
+        bool enable_dram_controller_model = false) const override {
         size_t num_niu_types = niu_id_to_attr_lookup.size();
         size_t num_links = link_id_to_attr_lookup.size();
-        return std::make_unique<npeDeviceState>(num_niu_types, num_links);
+        size_t num_dram_slots = enable_dram_controller_model ? getNumDramDemandSlots() : 0;
+        return std::make_unique<npeDeviceState>(num_niu_types, num_links, num_dram_slots);
     }
 
     void computeCurrentTransferRate(
@@ -212,7 +284,8 @@ class BlackholeDeviceModel : public npeDeviceModel {
         std::vector<PETransferState> &transfer_state,
         const std::vector<PETransferID> &live_transfer_ids,
         npeDeviceState &device_state,
-        bool enable_congestion_model) const override {
+        bool enable_congestion_model,
+        const DramCongestionParams &dram_params = {}) const override {
         // Compute bandwidth for this timestep for all live transfers
         updateTransferBandwidth(
             &transfer_state,
@@ -229,7 +302,9 @@ class BlackholeDeviceModel : public npeDeviceModel {
                 live_transfer_ids,
                 device_state.getNIUDemandGrid(),
                 device_state.getLinkDemandGrid(),
-                device_state.getMulticastWriteLinkDemandGrid());
+                device_state.getMulticastWriteLinkDemandGrid(),
+                device_state.getDramDemandGrid(),
+                dram_params);
         }
     }
 
@@ -299,6 +374,8 @@ class BlackholeDeviceModel : public npeDeviceModel {
         TT_ASSERT(dram_coord_to_controller_map.contains(local), "Could not find dram controller for coord {{ {}, {} }}", c.row, c.col);
         return dram_coord_to_controller_map.at(local);
     }
+
+    size_t getNumDramControllers() const override { return _num_distinct_dram_controllers; }
 
     BytesPerCycle getSrcInjectionRateByCoreType(CoreType core_type) const {
         auto it = core_type_to_inj_rate.find(core_type);
@@ -459,6 +536,9 @@ class BlackholeDeviceModel : public npeDeviceModel {
     const size_t _num_chips = 1;
     const float ai_clk_ghz = 1.35f;
     size_t NUM_DRAM_CONTROLLERS = 8; // P150
+    // distinct controller IDs present in dram_coord_to_controller_map; used for grid sizing
+    // only (see getNumDramControllers)
+    size_t _num_distinct_dram_controllers = 8;
     const double SINGLE_DIR_ETH_LINK_BW = 50;
 
     std::vector<nocLinkAttr> link_id_to_attr_lookup;

--- a/tt_npe/cpp/include/device_models/blackhole_multichip.hpp
+++ b/tt_npe/cpp/include/device_models/blackhole_multichip.hpp
@@ -81,10 +81,12 @@ class BlackholeMultichipDeviceModel : public npeDeviceModel {
      }
  
      // Initialize device state with appropriate dimensions for this device model
-     std::unique_ptr<npeDeviceState> initDeviceState() const override {
+     std::unique_ptr<npeDeviceState> initDeviceState(
+         bool enable_dram_controller_model = false) const override {
          size_t num_niu_types = niu_id_to_attr_lookup.size();
          size_t num_links = link_id_to_attr_lookup.size();
-         return std::make_unique<npeDeviceState>(num_niu_types, num_links);
+         size_t num_dram_slots = enable_dram_controller_model ? getNumDramDemandSlots() : 0;
+         return std::make_unique<npeDeviceState>(num_niu_types, num_links, num_dram_slots);
      }
  
      void modelCongestion(
@@ -93,7 +95,9 @@ class BlackholeMultichipDeviceModel : public npeDeviceModel {
          std::vector<PETransferState> &transfers,
          const std::vector<PETransferID> &live_transfer_ids,
          NIUDemandGrid &niu_demand_grid,
-         LinkDemandGrid &link_demand_grid) const {
+         LinkDemandGrid &link_demand_grid,
+         DramDemandGrid &dram_demand_grid,
+         const DramCongestionParams &dram_params) const {
          Cycle cycles_per_timestep = end_timestep - start_timestep;
  
          // assume all links have identical bandwidth
@@ -104,6 +108,11 @@ class BlackholeMultichipDeviceModel : public npeDeviceModel {
          // determine effective demand through each link
          std::fill(link_demand_grid.begin(), link_demand_grid.end(), 0.0f);
          std::fill(niu_demand_grid.begin(), niu_demand_grid.end(), 0.0f);
+         std::fill(dram_demand_grid.begin(), dram_demand_grid.end(), 0.0f);
+         // DRAM controller model is fully short-circuited when the grid was never sized.
+         const bool model_dram_controllers = !dram_demand_grid.empty();
+         const float DRAM_CONTROLLER_BANDWIDTH =
+             getDRAMControllerCongestionCapacity(dram_params.capacity_scale);
          for (auto ltid : live_transfer_ids) {
              auto &lt = transfers[ltid];
  
@@ -138,6 +147,22 @@ class BlackholeMultichipDeviceModel : public npeDeviceModel {
                  }
              }
  
+             // Track demand at the DRAM controller shared by several DRAM NIUs; see the
+             // equivalent block in blackhole.hpp for rationale. getDramDemandID() carries
+             // an explicit device_id stride because getDramControllerIDForCore() delegates
+             // to the single-chip model, which hardcodes device_id 0 -- without the stride
+             // controller IDs would collide across chips.
+             if (model_dram_controllers) {
+                 if (getCoreType(lt.params.src) == CoreType::DRAM) {
+                     dram_demand_grid[getDramDemandID(lt.params.src)] += effective_demand;
+                 }
+                 if (std::holds_alternative<Coord>(lt.params.dst)) {
+                     const auto &dram_dst = std::get<Coord>(lt.params.dst);
+                     if (getCoreType(dram_dst) == CoreType::DRAM) {
+                         dram_demand_grid[getDramDemandID(dram_dst)] += effective_demand;
+                     }
+                 }
+             }
              for (const auto &link_id : lt.route) {
                  link_demand_grid[link_id] += effective_demand;
              }
@@ -195,8 +220,29 @@ class BlackholeMultichipDeviceModel : public npeDeviceModel {
  
              auto min_niu_bw_derate = std::min(src_bw_derate, sink_bw_derate);
  
-             if (min_link_bw_derate < 1.0 || min_niu_bw_derate < 1.0) {
-                 float overall_bw_derate = std::min(min_link_bw_derate, min_niu_bw_derate);
+             // Derate against the shared DRAM controller; composed with min(), never a
+             // product -- see the extended note in blackhole.hpp.
+             float dram_bw_derate = 1.0f;
+             if (model_dram_controllers && dram_params.enforcing()) {
+                 if (getCoreType(lt.params.src) == CoreType::DRAM) {
+                     dram_bw_derate = std::min(
+                         dram_bw_derate,
+                         DRAM_CONTROLLER_BANDWIDTH /
+                             dram_demand_grid[getDramDemandID(lt.params.src)]);
+                 }
+                 if (std::holds_alternative<Coord>(lt.params.dst)) {
+                     const auto &dram_dst = std::get<Coord>(lt.params.dst);
+                     if (getCoreType(dram_dst) == CoreType::DRAM) {
+                         dram_bw_derate = std::min(
+                             dram_bw_derate,
+                             DRAM_CONTROLLER_BANDWIDTH /
+                                 dram_demand_grid[getDramDemandID(dram_dst)]);
+                     }
+                 }
+             }
+             if (min_link_bw_derate < 1.0 || min_niu_bw_derate < 1.0 || dram_bw_derate < 1.0) {
+                 float overall_bw_derate =
+                     std::min({min_link_bw_derate, min_niu_bw_derate, dram_bw_derate});
                  lt.curr_bandwidth *= overall_bw_derate;
              }
          }
@@ -209,7 +255,8 @@ class BlackholeMultichipDeviceModel : public npeDeviceModel {
          std::vector<PETransferState> &transfer_state,
          const std::vector<PETransferID> &live_transfer_ids,
          npeDeviceState &device_state,
-         bool enable_congestion_model) const override {
+         bool enable_congestion_model,
+         const DramCongestionParams &dram_params = {}) const override {
  
          // Compute bandwidth for this timestep for all live transfers
          updateTransferBandwidth(
@@ -226,7 +273,9 @@ class BlackholeMultichipDeviceModel : public npeDeviceModel {
                  transfer_state,
                  live_transfer_ids,
                  device_state.getNIUDemandGrid(),
-                 device_state.getLinkDemandGrid());
+                 device_state.getLinkDemandGrid(),
+                 device_state.getDramDemandGrid(),
+                 dram_params);
          }
      }
  
@@ -294,6 +343,9 @@ class BlackholeMultichipDeviceModel : public npeDeviceModel {
      }
      uint32_t getDramControllerIDForCore(const Coord &c) const override {
          return _blackhole_model.getDramControllerIDForCore(c);
+     }
+     size_t getNumDramControllers() const override {
+         return _blackhole_model.getNumDramControllers();
      }
  
      float getLinkBandwidth(const nocLinkID &link_id) const override { return _blackhole_model.getLinkBandwidth(link_id); }

--- a/tt_npe/cpp/include/device_models/wormhole_b0.hpp
+++ b/tt_npe/cpp/include/device_models/wormhole_b0.hpp
@@ -22,6 +22,14 @@ class WormholeB0DeviceModel : public npeDeviceModel {
         }
         populateNoCLinkLookups();
         populateNoCNIULookups();
+
+        // Derive the *grid sizing* controller count from the coordinate map rather than
+        // from NUM_DRAM_CONTROLLERS (see getNumDramControllers in npeDeviceModelIface).
+        _num_distinct_dram_controllers = 0;
+        for (const auto &[coord, controller_id] : dram_coord_to_controller_map) {
+            _num_distinct_dram_controllers =
+                std::max(_num_distinct_dram_controllers, size_t(controller_id) + 1);
+        }
     }
 
     void populateNoCLinkLookups() {
@@ -59,8 +67,15 @@ class WormholeB0DeviceModel : public npeDeviceModel {
         const std::vector<PETransferID> &live_transfer_ids,
         NIUDemandGrid &niu_demand_grid,
         LinkDemandGrid &link_demand_grid,
-        LinkDemandGrid &multicast_write_link_demand_grid) const {
+        LinkDemandGrid &multicast_write_link_demand_grid,
+        DramDemandGrid &dram_demand_grid,
+        const DramCongestionParams &dram_params) const {
         Cycle cycles_per_timestep = end_timestep - start_timestep;
+
+        // DRAM controller model is fully short-circuited when the grid was never sized.
+        const bool model_dram_controllers = !dram_demand_grid.empty();
+        const float DRAM_CONTROLLER_BANDWIDTH =
+            getDRAMControllerCongestionCapacity(dram_params.capacity_scale);
 
         // assume all links have identical bandwidth
         float LINK_BANDWIDTH = getLinkBandwidth(nocLinkID());
@@ -80,6 +95,7 @@ class WormholeB0DeviceModel : public npeDeviceModel {
                 multicast_write_link_demand_grid.begin(),
                 multicast_write_link_demand_grid.end(),
                 0.0f);
+            std::fill(dram_demand_grid.begin(), dram_demand_grid.end(), 0.0f);
             for (auto ltid : live_transfer_ids) {
                 auto &lt = transfers[ltid];
 
@@ -111,6 +127,25 @@ class WormholeB0DeviceModel : public npeDeviceModel {
                         if (getCoreType(c) == CoreType::WORKER) {
                             nocNIUID niu_id = getNIUID(c.row, c.col, sink_niu_type);
                             niu_demand_grid[niu_id] += effective_demand;
+                        }
+                    }
+                }
+
+                // Track demand at the DRAM controller shared by several DRAM NIUs. The
+                // per-NIU grid above is keyed by (coord, nocNIUType), so the 3 DRAM NIU
+                // coords of one controller -- and NOC0 vs NOC1 traffic to the same coord --
+                // land in separate buckets and can each look unsaturated while the
+                // controller behind them is oversubscribed. This grid is the one place
+                // where that traffic is summed. Multicast is skipped: the sink loop above
+                // already restricts multicast sinks to WORKER cores.
+                if (model_dram_controllers) {
+                    if (getCoreType(lt.params.src) == CoreType::DRAM) {
+                        dram_demand_grid[getDramDemandID(lt.params.src)] += effective_demand;
+                    }
+                    if (std::holds_alternative<Coord>(lt.params.dst)) {
+                        const auto &dst = std::get<Coord>(lt.params.dst);
+                        if (getCoreType(dst) == CoreType::DRAM) {
+                            dram_demand_grid[getDramDemandID(dst)] += effective_demand;
                         }
                     }
                 }
@@ -179,8 +214,42 @@ class WormholeB0DeviceModel : public npeDeviceModel {
 
                 auto min_niu_bw_derate = std::min(src_bw_derate, sink_bw_derate);
 
-                if (min_link_bw_derate < 1.0 || min_niu_bw_derate < 1.0) {
-                    float overall_bw_derate = std::min(min_link_bw_derate, min_niu_bw_derate);
+                // Derate against the shared DRAM controller. Structurally identical to the
+                // sink NIU derate above (capacity / demand).
+                //
+                // NOTE ON DOUBLE COUNTING: derates are composed with min(), never a
+                // product. min() is the correct operator for *nested* resources -- a
+                // transfer is limited by the tightest of {links on its route, its own NIU,
+                // the controller that NIU shares}. A single DRAM NIU can only demand up to
+                // its own absorption rate (23.2-24.0 B/cyc here), which is below the
+                // controller capacity (47.2 B/cyc), so the controller term is inert for
+                // uncontended traffic and only binds once several NIUs of one controller
+                // are active together. Keep BOTH terms: dropping the NIU derate on DRAM
+                // coords would let a single NIU reach full controller bandwidth, which is
+                // wrong in the other direction.
+                float dram_bw_derate = 1.0f;
+                if (model_dram_controllers && dram_params.enforcing()) {
+                    if (getCoreType(lt.params.src) == CoreType::DRAM) {
+                        dram_bw_derate = std::min(
+                            dram_bw_derate,
+                            DRAM_CONTROLLER_BANDWIDTH /
+                                dram_demand_grid[getDramDemandID(lt.params.src)]);
+                    }
+                    if (std::holds_alternative<Coord>(lt.params.dst)) {
+                        const auto &dst = std::get<Coord>(lt.params.dst);
+                        if (getCoreType(dst) == CoreType::DRAM) {
+                            dram_bw_derate = std::min(
+                                dram_bw_derate,
+                                DRAM_CONTROLLER_BANDWIDTH /
+                                    dram_demand_grid[getDramDemandID(dst)]);
+                        }
+                    }
+                }
+
+                if (min_link_bw_derate < 1.0 || min_niu_bw_derate < 1.0 ||
+                    dram_bw_derate < 1.0) {
+                    float overall_bw_derate =
+                        std::min({min_link_bw_derate, min_niu_bw_derate, dram_bw_derate});
 
                     lt.curr_bandwidth *= 1.0 - (grad_fac * (1.0f - overall_bw_derate));
                 }
@@ -188,10 +257,12 @@ class WormholeB0DeviceModel : public npeDeviceModel {
         }
     }
 
-    std::unique_ptr<npeDeviceState> initDeviceState() const override {
+    std::unique_ptr<npeDeviceState> initDeviceState(
+        bool enable_dram_controller_model = false) const override {
         size_t num_niu_types = niu_id_to_attr_lookup.size();
         size_t num_links = link_id_to_attr_lookup.size();
-        return std::make_unique<npeDeviceState>(num_niu_types, num_links);
+        size_t num_dram_slots = enable_dram_controller_model ? getNumDramDemandSlots() : 0;
+        return std::make_unique<npeDeviceState>(num_niu_types, num_links, num_dram_slots);
     }
 
     void computeCurrentTransferRate(
@@ -200,7 +271,8 @@ class WormholeB0DeviceModel : public npeDeviceModel {
         std::vector<PETransferState> &transfer_state,
         const std::vector<PETransferID> &live_transfer_ids,
         npeDeviceState &device_state,
-        bool enable_congestion_model) const override {
+        bool enable_congestion_model,
+        const DramCongestionParams &dram_params = {}) const override {
         // Compute bandwidth for this timestep for all live transfers
         updateTransferBandwidth(
             &transfer_state,
@@ -217,7 +289,9 @@ class WormholeB0DeviceModel : public npeDeviceModel {
                 live_transfer_ids,
                 device_state.getNIUDemandGrid(),
                 device_state.getLinkDemandGrid(),
-                device_state.getMulticastWriteLinkDemandGrid());
+                device_state.getMulticastWriteLinkDemandGrid(),
+                device_state.getDramDemandGrid(),
+                dram_params);
         }
     }
 
@@ -287,6 +361,8 @@ class WormholeB0DeviceModel : public npeDeviceModel {
         TT_ASSERT(dram_coord_to_controller_map.contains(local), "Could not find dram controller for coord {{ {}, {} }}", c.row, c.col);
         return dram_coord_to_controller_map.at(local);
     }
+
+    size_t getNumDramControllers() const override { return _num_distinct_dram_controllers; }
 
     BytesPerCycle getSrcInjectionRateByCoreType(CoreType core_type) const {
         auto it = core_type_to_inj_rate.find(core_type);
@@ -446,6 +522,9 @@ class WormholeB0DeviceModel : public npeDeviceModel {
     static const size_t _num_cols = 10;
     const size_t _num_chips = 1;
     size_t NUM_DRAM_CONTROLLERS = 6;
+    // distinct controller IDs present in dram_coord_to_controller_map; used for grid sizing
+    // only (see getNumDramControllers)
+    size_t _num_distinct_dram_controllers = 6;
     const double SINGLE_DIR_ETH_LINK_BW = 12.5;
 
     std::vector<nocLinkAttr> link_id_to_attr_lookup;

--- a/tt_npe/cpp/include/device_models/wormhole_multichip.hpp
+++ b/tt_npe/cpp/include/device_models/wormhole_multichip.hpp
@@ -81,10 +81,12 @@ class WormholeMultichipDeviceModel : public npeDeviceModel {
     }
 
     // Initialize device state with appropriate dimensions for this device model
-    std::unique_ptr<npeDeviceState> initDeviceState() const override {
+    std::unique_ptr<npeDeviceState> initDeviceState(
+        bool enable_dram_controller_model = false) const override {
         size_t num_niu_types = niu_id_to_attr_lookup.size();
         size_t num_links = link_id_to_attr_lookup.size();
-        return std::make_unique<npeDeviceState>(num_niu_types, num_links);
+        size_t num_dram_slots = enable_dram_controller_model ? getNumDramDemandSlots() : 0;
+        return std::make_unique<npeDeviceState>(num_niu_types, num_links, num_dram_slots);
     }
 
     void modelCongestion(
@@ -94,13 +96,20 @@ class WormholeMultichipDeviceModel : public npeDeviceModel {
         const std::vector<PETransferID> &live_transfer_ids,
         NIUDemandGrid &niu_demand_grid,
         LinkDemandGrid &link_demand_grid,
-        LinkDemandGrid &multicast_write_link_demand_grid) const {
+        LinkDemandGrid &multicast_write_link_demand_grid,
+        DramDemandGrid &dram_demand_grid,
+        const DramCongestionParams &dram_params) const {
         Cycle cycles_per_timestep = end_timestep - start_timestep;
 
         // assume all links have identical bandwidth
         float LINK_BANDWIDTH = getLinkBandwidth(nocLinkID());
         static auto worker_sink_absorption_rate =
             _wormhole_b0_model.getSinkAbsorptionRateByCoreType(CoreType::WORKER);
+
+        // DRAM controller model is fully short-circuited when the grid was never sized.
+        const bool model_dram_controllers = !dram_demand_grid.empty();
+        const float DRAM_CONTROLLER_BANDWIDTH =
+            getDRAMControllerCongestionCapacity(dram_params.capacity_scale);
 
         // determine effective demand through each link
         std::fill(link_demand_grid.begin(), link_demand_grid.end(), 0.0f);
@@ -109,6 +118,7 @@ class WormholeMultichipDeviceModel : public npeDeviceModel {
             multicast_write_link_demand_grid.begin(),
             multicast_write_link_demand_grid.end(),
             0.0f);
+        std::fill(dram_demand_grid.begin(), dram_demand_grid.end(), 0.0f);
         for (auto ltid : live_transfer_ids) {
             auto &lt = transfers[ltid];
 
@@ -139,6 +149,23 @@ class WormholeMultichipDeviceModel : public npeDeviceModel {
                     if (getCoreType(c) == CoreType::WORKER) {
                         nocNIUID niu_id = getNIUID(c.device_id, c.row, c.col, sink_niu_type);
                         niu_demand_grid[niu_id] += effective_demand;
+                    }
+                }
+            }
+
+            // Track demand at the DRAM controller shared by several DRAM NIUs; see the
+            // equivalent block in wormhole_b0.hpp for rationale. getDramDemandID() carries
+            // an explicit device_id stride because getDramControllerIDForCore() delegates
+            // to the single-chip model, which hardcodes device_id 0 -- without the stride
+            // controller IDs would collide across chips.
+            if (model_dram_controllers) {
+                if (getCoreType(lt.params.src) == CoreType::DRAM) {
+                    dram_demand_grid[getDramDemandID(lt.params.src)] += effective_demand;
+                }
+                if (std::holds_alternative<Coord>(lt.params.dst)) {
+                    const auto &dram_dst = std::get<Coord>(lt.params.dst);
+                    if (getCoreType(dram_dst) == CoreType::DRAM) {
+                        dram_demand_grid[getDramDemandID(dram_dst)] += effective_demand;
                     }
                 }
             }
@@ -208,8 +235,30 @@ class WormholeMultichipDeviceModel : public npeDeviceModel {
 
             auto min_niu_bw_derate = std::min(src_bw_derate, sink_bw_derate);
 
-            if (min_link_bw_derate < 1.0 || min_niu_bw_derate < 1.0) {
-                float overall_bw_derate = std::min(min_link_bw_derate, min_niu_bw_derate);
+            // Derate against the shared DRAM controller; composed with min(), never a
+            // product -- see the extended note in wormhole_b0.hpp.
+            float dram_bw_derate = 1.0f;
+            if (model_dram_controllers && dram_params.enforcing()) {
+                if (getCoreType(lt.params.src) == CoreType::DRAM) {
+                    dram_bw_derate = std::min(
+                        dram_bw_derate,
+                        DRAM_CONTROLLER_BANDWIDTH /
+                            dram_demand_grid[getDramDemandID(lt.params.src)]);
+                }
+                if (std::holds_alternative<Coord>(lt.params.dst)) {
+                    const auto &dram_dst = std::get<Coord>(lt.params.dst);
+                    if (getCoreType(dram_dst) == CoreType::DRAM) {
+                        dram_bw_derate = std::min(
+                            dram_bw_derate,
+                            DRAM_CONTROLLER_BANDWIDTH /
+                                dram_demand_grid[getDramDemandID(dram_dst)]);
+                    }
+                }
+            }
+
+            if (min_link_bw_derate < 1.0 || min_niu_bw_derate < 1.0 || dram_bw_derate < 1.0) {
+                float overall_bw_derate =
+                    std::min({min_link_bw_derate, min_niu_bw_derate, dram_bw_derate});
                 lt.curr_bandwidth *= overall_bw_derate;
             }
         }
@@ -222,7 +271,8 @@ class WormholeMultichipDeviceModel : public npeDeviceModel {
         std::vector<PETransferState> &transfer_state,
         const std::vector<PETransferID> &live_transfer_ids,
         npeDeviceState &device_state,
-        bool enable_congestion_model) const override {
+        bool enable_congestion_model,
+        const DramCongestionParams &dram_params = {}) const override {
 
         // Compute bandwidth for this timestep for all live transfers
         updateTransferBandwidth(
@@ -240,7 +290,9 @@ class WormholeMultichipDeviceModel : public npeDeviceModel {
                 live_transfer_ids,
                 device_state.getNIUDemandGrid(),
                 device_state.getLinkDemandGrid(),
-                device_state.getMulticastWriteLinkDemandGrid());
+                device_state.getMulticastWriteLinkDemandGrid(),
+                device_state.getDramDemandGrid(),
+                dram_params);
         }
     }
 
@@ -299,6 +351,9 @@ class WormholeMultichipDeviceModel : public npeDeviceModel {
     // we can directly reuse wormhole_b0 implementations.
     CoreType getCoreType(const Coord &c) const override {
         return _wormhole_b0_model.getCoreType(c);
+    }
+    size_t getNumDramControllers() const override {
+        return _wormhole_b0_model.getNumDramControllers();
     }
     uint32_t getDramControllerIDForCore(const Coord &c) const override {
         return _wormhole_b0_model.getDramControllerIDForCore(c);

--- a/tt_npe/cpp/include/grid.hpp
+++ b/tt_npe/cpp/include/grid.hpp
@@ -101,5 +101,9 @@ class Grid3D {
 
 using LinkDemandGrid = std::vector<float>;
 using NIUDemandGrid = std::vector<float>;
+// Per-DRAM-controller demand, flattened as (device_id * num_dram_controllers + controller_id).
+// Multiple DRAM NIUs share a single controller, so this grid aggregates demand that the
+// per-NIU grid necessarily sees as independent.
+using DramDemandGrid = std::vector<float>;
 
 }  // namespace tt_npe

--- a/tt_npe/cpp/include/npeCommon.hpp
+++ b/tt_npe/cpp/include/npeCommon.hpp
@@ -36,6 +36,25 @@ enum CoreType {
     ETH = 3,
 };
 
+// Controls the per-DRAM-controller congestion model.
+//   Off     : no grid is allocated; every new code path is skipped. Bit-identical to
+//             the behavior before the DRAM controller model existed.
+//   Observe : demand is accumulated and reported, but never derates bandwidth. Cycle
+//             predictions are therefore identical to Off.
+//   Enforce : demand is accumulated, reported, AND derates transfer bandwidth.
+enum class DramCongestionMode : uint8_t { Off = 0, Observe = 1, Enforce = 2 };
+
+struct DramCongestionParams {
+    DramCongestionMode mode = DramCongestionMode::Off;
+    // Scales getDRAMBandwidthPerController() to obtain the capacity used *only* by the
+    // congestion model. Kept separate so calibrating congestion never moves the
+    // published dram_bw_util / dram_bw_util_per_controller numbers.
+    float capacity_scale = 1.0f;
+
+    bool enabled() const { return mode != DramCongestionMode::Off; }
+    bool enforcing() const { return mode == DramCongestionMode::Enforce; }
+};
+
 class npeException : std::exception {
    public:
     npeException(const npeException &error) = default;

--- a/tt_npe/cpp/include/npeConfig.hpp
+++ b/tt_npe/cpp/include/npeConfig.hpp
@@ -17,6 +17,14 @@ enum class VerbosityLevel { Normal = 0, Verbose = 1, MoreVerbose = 2, MostVerbos
 struct npeConfig {
     std::string device_name = "wormhole_b0";
     std::string congestion_model_name = "fast";
+    // Per-DRAM-controller congestion model: "off" | "observe" | "enforce".
+    // Defaults to "off" so existing predictions are bit-identical; "observe" reports
+    // per-controller demand without derating (cycles still identical to "off").
+    std::string dram_controller_model = "off";
+    // Scales getDRAMBandwidthPerController() for congestion purposes only. The Blackhole
+    // per-controller constant (40.0 B/cyc) and tt-metal's datasheet figure (512 GB/s =>
+    // 47.4 B/cyc) disagree by ~19%, so this is the calibration knob for that band.
+    float dram_controller_capacity_scale = 1.0f;
     std::string workload_json;
     Cycle cycles_per_timestep = 128;
     VerbosityLevel verbosity = VerbosityLevel::Normal;
@@ -32,6 +40,26 @@ struct npeConfig {
     float scale_workload_schedule = 0.0f;
     std::string topology_json; // Path to topology JSON file
     Timestep timeline_split_threshold_timesteps = 10000; // Threshold for splitting timeline files
+
+    // Translates dram_controller_model into the struct the device models consume.
+    // Returns Off for any unrecognized string; validateConfig() rejects those up front so
+    // a typo is a hard error rather than a silently disabled feature.
+    DramCongestionParams getDramCongestionParams() const {
+        DramCongestionParams params;
+        if (dram_controller_model == "observe") {
+            params.mode = DramCongestionMode::Observe;
+        } else if (dram_controller_model == "enforce") {
+            params.mode = DramCongestionMode::Enforce;
+        } else {
+            params.mode = DramCongestionMode::Off;
+        }
+        params.capacity_scale = dram_controller_capacity_scale;
+        return params;
+    }
+
+    static bool isValidDramControllerModel(const std::string &name) {
+        return name == "off" || name == "observe" || name == "enforce";
+    }
 
     void setVerbosityLevel(int vlvl) {
         vlvl = std::clamp(vlvl, 0, 3);
@@ -50,6 +78,9 @@ struct npeConfig {
         repr += fmt::format("\n  timeline_filepath                  = \"{}\"", timeline_filepath);
         repr += "\n";
         repr += fmt::format("\n  congestion_model_name              = {}", congestion_model_name);
+        repr += fmt::format("\n  dram_controller_model              = {}", dram_controller_model);
+        repr += fmt::format(
+            "\n  dram_controller_capacity_scale     = {}", dram_controller_capacity_scale);
         repr += fmt::format("\n  estimate_cong_impact               = {}", estimate_cong_impact);
         repr += fmt::format("\n  cycles_per_timestep                = {}", cycles_per_timestep);
         repr += fmt::format(

--- a/tt_npe/cpp/include/npeDeviceModelIface.hpp
+++ b/tt_npe/cpp/include/npeDeviceModelIface.hpp
@@ -28,8 +28,11 @@ class npeDeviceModel {
     virtual nocRoute route(
         nocType noc_type, const Coord &startpoint, const NocDestination &destination) const = 0;
 
-    // Initialize device state with appropriate dimensions for this device model
-    virtual std::unique_ptr<npeDeviceState> initDeviceState() const = 0;
+    // Initialize device state with appropriate dimensions for this device model.
+    // When enable_dram_controller_model is false the DRAM controller demand grid is left
+    // empty, which short-circuits every DRAM-controller code path in modelCongestion.
+    virtual std::unique_ptr<npeDeviceState> initDeviceState(
+        bool enable_dram_controller_model = false) const = 0;
 
     // Compute current transfer rate using device state
     virtual void computeCurrentTransferRate(
@@ -38,7 +41,8 @@ class npeDeviceModel {
         std::vector<PETransferState> &transfer_state,
         const std::vector<PETransferID> &live_transfer_ids,
         npeDeviceState &device_state,
-        bool enable_congestion_model) const = 0;
+        bool enable_congestion_model,
+        const DramCongestionParams &dram_params = {}) const = 0;
 
     virtual DeviceArch getArch() const = 0;
 
@@ -60,6 +64,24 @@ class npeDeviceModel {
     virtual CoreType getCoreType(const Coord &c) const = 0;
     virtual uint32_t getDramControllerIDForCore(const Coord &c) const = 0;
 
+    // Number of distinct DRAM controller IDs emitted by getDramControllerIDForCore() for a
+    // single chip. NOTE: this is deliberately NOT the same thing as the model's
+    // NUM_DRAM_CONTROLLERS constant used for aggregate bandwidth arithmetic -- under
+    // Blackhole SINGLE_BANK_HARVESTING that constant is 7 while the coordinate map still
+    // emits IDs 0..7. Grids must be sized off this value to stay in bounds.
+    virtual size_t getNumDramControllers() const = 0;
+
+    // Flattened index of a DRAM coordinate's controller in a DramDemandGrid.
+    // The device_id stride is mandatory: multichip models delegate
+    // getDramControllerIDForCore() to their single-chip member, whose implementation
+    // hardcodes device_id 0, so controller IDs collide across chips without it.
+    size_t getDramDemandID(const Coord &c) const {
+        return size_t(c.device_id) * getNumDramControllers() + getDramControllerIDForCore(c);
+    }
+
+    // Total number of DramDemandGrid slots needed for this model.
+    size_t getNumDramDemandSlots() const { return getNumChips() * getNumDramControllers(); }
+
     virtual BytesPerCycle getSrcInjectionRate(const Coord &c) const = 0;
     virtual BytesPerCycle getSinkAbsorptionRate(const Coord &c) const = 0;
 
@@ -67,6 +89,13 @@ class npeDeviceModel {
 
     virtual float getDRAMBandwidthPerChip() const = 0;
     virtual float getDRAMBandwidthPerController() const = 0;
+
+    // Per-controller capacity used by the *congestion model only*. Deliberately routed
+    // through a scale factor so that calibrating congestion never perturbs the published
+    // dram_bw_util / dram_bw_util_per_controller reporting numbers.
+    float getDRAMControllerCongestionCapacity(float capacity_scale) const {
+        return getDRAMBandwidthPerController() * capacity_scale;
+    }
 
     virtual float getEthBandwidthPerLink() const = 0;
 };

--- a/tt_npe/cpp/include/npeDeviceModelUtils.hpp
+++ b/tt_npe/cpp/include/npeDeviceModelUtils.hpp
@@ -69,6 +69,8 @@ inline void updateSimulationStats(
     const LinkDemandGrid &link_demand_grid,
     const LinkDemandGrid &multicast_write_link_demand_grid,
     const NIUDemandGrid &niu_demand_grid,
+    const DramDemandGrid &dram_demand_grid,
+    float dram_controller_capacity,
     std::vector<int> &live_transfer_ids,
     npeStats &stats) {
     float max_link_bandwidth = device_model.getLinkBandwidth(nocLinkID(0));
@@ -129,6 +131,15 @@ inline void updateSimulationStats(
         size_t niu_demand_grid_size = device_id == MESH_DEVICE ? niu_demand_grid.size() : niu_demand_grid.size() / device_model.getNumChips();
         sim_stats.avg_niu_demand *= 100. / (max_link_bandwidth * niu_demand_grid.size());
         sim_stats.max_niu_demand *= 100. / max_link_bandwidth;
+
+        // Retain the per-DRAM-controller demand for this timestep. Unlike the link/NIU
+        // grids (thousands of floats, hence the MESH_DEVICE-only guard below) this is
+        // 6-8 floats per chip, so keeping it for every device is free. It is empty when
+        // the DRAM controller model is disabled.
+        if (!dram_demand_grid.empty()) {
+            deviceStats.dram_controller_capacity = dram_controller_capacity;
+            sim_stats.dram_demand_grid = dram_demand_grid;
+        }
 
         // NOTE: copying these is a 10% runtime overhead, so disable these for per device stats
         if (device_id == MESH_DEVICE) {

--- a/tt_npe/cpp/include/npeDeviceState.hpp
+++ b/tt_npe/cpp/include/npeDeviceState.hpp
@@ -11,12 +11,15 @@ namespace tt_npe {
 // Class to encapsulate device state information including NIU and link demand grids
 class npeDeviceState {
 public:
-    // Constructor takes the number of NIUs (indexed by nocNIUID) and links for demand grids
-    npeDeviceState(size_t num_nius, size_t num_links) :
+    // Constructor takes the number of NIUs (indexed by nocNIUID) and links for demand grids.
+    // num_dram_slots is (num_chips * num_dram_controllers_per_chip); passing 0 (the default)
+    // leaves the DRAM controller demand grid empty, which disables the DRAM congestion model.
+    npeDeviceState(size_t num_nius, size_t num_links, size_t num_dram_slots = 0) :
         niu_demand_grid(num_nius, 0.0f),
         link_demand_grid(num_links, 0.0f),
-        multicast_write_link_demand_grid(num_links, 0.0f) {}
-    
+        multicast_write_link_demand_grid(num_links, 0.0f),
+        dram_demand_grid(num_dram_slots, 0.0f) {}
+
     // Reset all demand grids to zero
     void reset() {
         std::fill(niu_demand_grid.begin(), niu_demand_grid.end(), 0.0f);
@@ -25,23 +28,27 @@ public:
             multicast_write_link_demand_grid.begin(),
             multicast_write_link_demand_grid.end(),
             0.0f);
+        std::fill(dram_demand_grid.begin(), dram_demand_grid.end(), 0.0f);
     }
-    
+
     // Accessors
     NIUDemandGrid& getNIUDemandGrid() { return niu_demand_grid; }
     LinkDemandGrid& getLinkDemandGrid() { return link_demand_grid; }
     LinkDemandGrid& getMulticastWriteLinkDemandGrid() { return multicast_write_link_demand_grid; }
-    
+    DramDemandGrid& getDramDemandGrid() { return dram_demand_grid; }
+
     const NIUDemandGrid& getNIUDemandGrid() const { return niu_demand_grid; }
     const LinkDemandGrid& getLinkDemandGrid() const { return link_demand_grid; }
     const LinkDemandGrid& getMulticastWriteLinkDemandGrid() const {
         return multicast_write_link_demand_grid;
     }
-    
+    const DramDemandGrid& getDramDemandGrid() const { return dram_demand_grid; }
+
 private:
     NIUDemandGrid niu_demand_grid;
     LinkDemandGrid link_demand_grid;
     LinkDemandGrid multicast_write_link_demand_grid;
+    DramDemandGrid dram_demand_grid;
 };
 
 } // namespace tt_npe

--- a/tt_npe/cpp/include/npeStats.hpp
+++ b/tt_npe/cpp/include/npeStats.hpp
@@ -43,7 +43,28 @@ struct TimestepStats {
 
     LinkDemandGrid link_demand_grid;
     NIUDemandGrid niu_demand_grid;
+    // Per-DRAM-controller demand for this timestep, in bytes/cycle. Empty unless the DRAM
+    // controller model is enabled. Unlike the link/NIU grids this one is retained for every
+    // device (not just MESH_DEVICE) because it is tiny -- 6-8 floats per chip.
+    DramDemandGrid dram_demand_grid;
     std::vector<int> live_transfer_ids;
+};
+
+// A DRAM controller whose aggregate demand approached or exceeded its bandwidth. This is
+// the signal the per-NIU view cannot produce: several DRAM NIUs share one controller, so
+// each can look unsaturated while the controller behind them is oversubscribed.
+struct DramHotspot {
+    uint32_t controller_id = 0;
+    DeviceID device_id = 0;
+    // peak / mean per-timestep demand as a percentage of controller bandwidth
+    double peak_demand_pct = 0;
+    double mean_demand_pct = 0;
+    // fraction of simulated timesteps in which demand met or exceeded capacity
+    double saturated_frac = 0;
+    // saturated_frac expressed in estimated cycles
+    double saturated_cycles = 0;
+
+    std::string to_string() const;
 };
 
 // various results from npe simulation
@@ -77,6 +98,28 @@ struct npeStats {
         double dram_bw_util_sim = 0;
         std::unordered_map<Coord, double> eth_bw_util_per_core;
         std::unordered_map<uint32_t, double> dram_bw_util_per_controller;
+
+        //---- per-DRAM-controller congestion stats -----------------------------------
+        // All of these are simulator outputs derived from the per-timestep DRAM demand
+        // grid; they are zero/empty unless the DRAM controller model was enabled. This is
+        // the distinction from dram_bw_util* above, which are post-hoc quantities computed
+        // from the static workload divided by a cycle count.
+        //
+        // Map keys are the DRAM controller ID for a single-device deviceStats, and the
+        // flattened grid slot (device_id * num_controllers + controller_id) for
+        // MESH_DEVICE. The two coincide on single-chip parts.
+        double overall_max_dram_controller_demand = 0;  // % of controller bandwidth
+        double overall_avg_dram_controller_demand = 0;  // % of controller bandwidth
+        std::unordered_map<uint32_t, double> dram_controller_peak_demand;
+        std::unordered_map<uint32_t, double> dram_controller_mean_demand;
+        std::unordered_map<uint32_t, double> dram_controller_saturated_frac;
+        // congestion-model capacity per controller in bytes/cycle (0 if model disabled)
+        double dram_controller_capacity = 0;
+        // number of DRAM controllers per chip, and the device these stats belong to;
+        // together these decompose a MESH_DEVICE map key back into (device, controller)
+        size_t dram_num_controllers = 0;
+        DeviceID dram_stats_device_id = 0;
+
         std::vector<TimestepStats> per_timestep_stats;
 
         std::string to_string(bool verbose = false) const;
@@ -96,7 +139,23 @@ struct npeStats {
         // returns aggregate (average) ETH BW util across all cores
         double getAggregateEthBwUtil() const;
 
+        // returns DRAM controllers whose peak demand reached threshold_pct of controller
+        // bandwidth, sorted by saturated_frac then peak demand (both descending).
+        // Always empty when the DRAM controller model is disabled.
+        std::vector<DramHotspot> getDRAMHotspots(double threshold_pct = 90.0) const;
+
+        // returns DRAM hotspots as a single formatted line
+        std::string getDRAMHotspotStr() const;
+
+        // true if any DRAM controller was saturated for more than half the runtime, i.e.
+        // the workload is DRAM-bandwidth-bound rather than NoC-fabric-bound
+        bool isDRAMBound() const;
+
         private:
+        // reduces the per-timestep DRAM demand grids into the per-controller summary
+        // fields above; no-op when the DRAM controller model was disabled
+        void computeDramControllerStats(const npeDeviceModel& device_model, DeviceID device_id);
+
         // just for computing estimated_cycles, not to be reported in output
         Cycle worst_case_transfer_end_cycle = 0;
         friend npeStats;

--- a/tt_npe/cpp/pybind/bindings.cpp
+++ b/tt_npe/cpp/pybind/bindings.cpp
@@ -36,6 +36,22 @@ PYBIND11_MODULE(tt_npe_pybind, m) {
         },
         "Constructs a new `npe.API` handle given an `npe.Config` object");
 
+    // Bind DramHotspot before deviceStats, which returns a vector of them
+    py::class_<tt_npe::DramHotspot>(
+        m,
+        "DramHotspot",
+        "A DRAM controller whose aggregate demand approached or exceeded its bandwidth. "
+        "Several DRAM NIUs share one controller, so this is a bottleneck the per-NIU view "
+        "cannot show.")
+        .def_readonly("controller_id", &tt_npe::DramHotspot::controller_id)
+        .def_readonly("device_id", &tt_npe::DramHotspot::device_id)
+        .def_readonly("peak_demand_pct", &tt_npe::DramHotspot::peak_demand_pct)
+        .def_readonly("mean_demand_pct", &tt_npe::DramHotspot::mean_demand_pct)
+        .def_readonly("saturated_frac", &tt_npe::DramHotspot::saturated_frac)
+        .def_readonly("saturated_cycles", &tt_npe::DramHotspot::saturated_cycles)
+        .def("__repr__", &tt_npe::DramHotspot::to_string)
+        .def("__str__", &tt_npe::DramHotspot::to_string);
+
     // Bind the nested deviceStats struct first
     py::class_<tt_npe::npeStats::deviceStats> device_stats(
         m,
@@ -65,6 +81,38 @@ PYBIND11_MODULE(tt_npe_pybind, m) {
         .def_readwrite("dram_bw_util_sim", &tt_npe::npeStats::deviceStats::dram_bw_util_sim)
         .def_readwrite("eth_bw_util_per_core", &tt_npe::npeStats::deviceStats::eth_bw_util_per_core)
         .def_readwrite("dram_bw_util_per_controller", &tt_npe::npeStats::deviceStats::dram_bw_util_per_controller)
+        .def_readwrite(
+            "overall_max_dram_controller_demand",
+            &tt_npe::npeStats::deviceStats::overall_max_dram_controller_demand)
+        .def_readwrite(
+            "overall_avg_dram_controller_demand",
+            &tt_npe::npeStats::deviceStats::overall_avg_dram_controller_demand)
+        .def_readwrite(
+            "dram_controller_peak_demand",
+            &tt_npe::npeStats::deviceStats::dram_controller_peak_demand)
+        .def_readwrite(
+            "dram_controller_mean_demand",
+            &tt_npe::npeStats::deviceStats::dram_controller_mean_demand)
+        .def_readwrite(
+            "dram_controller_saturated_frac",
+            &tt_npe::npeStats::deviceStats::dram_controller_saturated_frac)
+        .def_readwrite(
+            "dram_controller_capacity",
+            &tt_npe::npeStats::deviceStats::dram_controller_capacity)
+        .def(
+            "getDRAMHotspots",
+            &tt_npe::npeStats::deviceStats::getDRAMHotspots,
+            py::arg("threshold_pct") = 90.0,
+            "Returns DRAM controllers whose peak demand reached threshold_pct of "
+            "controller bandwidth; empty unless the DRAM controller model is enabled")
+        .def(
+            "getDRAMHotspotStr",
+            &tt_npe::npeStats::deviceStats::getDRAMHotspotStr,
+            "Returns DRAM controller hotspots as a formatted string")
+        .def(
+            "isDRAMBound",
+            &tt_npe::npeStats::deviceStats::isDRAMBound,
+            "True if any DRAM controller was saturated for more than half the runtime")
         .def(
             "getCongestionImpact",
             &tt_npe::npeStats::deviceStats::getCongestionImpact,
@@ -100,6 +148,18 @@ PYBIND11_MODULE(tt_npe_pybind, m) {
             for (const auto& [controller, util] : ds.dram_bw_util_per_controller) {
                 dram_bw_dict[py::cast(controller)] = util;
             }
+            py::dict dram_ctrl_peak_dict;
+            for (const auto& [controller, val] : ds.dram_controller_peak_demand) {
+                dram_ctrl_peak_dict[py::cast(controller)] = val;
+            }
+            py::dict dram_ctrl_mean_dict;
+            for (const auto& [controller, val] : ds.dram_controller_mean_demand) {
+                dram_ctrl_mean_dict[py::cast(controller)] = val;
+            }
+            py::dict dram_ctrl_sat_dict;
+            for (const auto& [controller, val] : ds.dram_controller_saturated_frac) {
+                dram_ctrl_sat_dict[py::cast(controller)] = val;
+            }
             return py::make_tuple(
                 ds.completed,
                 ds.estimated_cycles,
@@ -123,10 +183,19 @@ PYBIND11_MODULE(tt_npe_pybind, m) {
                 ds.dram_bw_util,
                 ds.dram_bw_util_sim,
                 eth_bw_list,
-                dram_bw_dict);
+                dram_bw_dict,
+                // appended by the per-DRAM-controller congestion model; older pickles
+                // simply lack these and are still accepted (see __setstate__)
+                ds.overall_max_dram_controller_demand,
+                ds.overall_avg_dram_controller_demand,
+                dram_ctrl_peak_dict,
+                dram_ctrl_mean_dict,
+                dram_ctrl_sat_dict,
+                ds.dram_controller_capacity);
         },
         [](py::tuple t) {
-            if (t.size() != 23) {
+            // 23 == pre-DRAM-controller-model pickles, 29 == current
+            if (t.size() != 23 && t.size() != 29) {
                 throw std::runtime_error("Invalid deviceStats pickle state!");
             }
             tt_npe::npeStats::deviceStats ds;
@@ -164,6 +233,23 @@ PYBIND11_MODULE(tt_npe_pybind, m) {
             py::dict dram_bw_dict = t[22].cast<py::dict>();
             for (const auto& item : dram_bw_dict) {
                 ds.dram_bw_util_per_controller[item.first.cast<uint32_t>()] = item.second.cast<double>();
+            }
+            if (t.size() == 29) {
+                ds.overall_max_dram_controller_demand = t[23].cast<double>();
+                ds.overall_avg_dram_controller_demand = t[24].cast<double>();
+                for (const auto& item : t[25].cast<py::dict>()) {
+                    ds.dram_controller_peak_demand[item.first.cast<uint32_t>()] =
+                        item.second.cast<double>();
+                }
+                for (const auto& item : t[26].cast<py::dict>()) {
+                    ds.dram_controller_mean_demand[item.first.cast<uint32_t>()] =
+                        item.second.cast<double>();
+                }
+                for (const auto& item : t[27].cast<py::dict>()) {
+                    ds.dram_controller_saturated_frac[item.first.cast<uint32_t>()] =
+                        item.second.cast<double>();
+                }
+                ds.dram_controller_capacity = t[28].cast<double>();
             }
             return ds;
         }));
@@ -216,6 +302,10 @@ PYBIND11_MODULE(tt_npe_pybind, m) {
         .def(py::init<>())
         .def_readwrite("device_name", &tt_npe::npeConfig::device_name)
         .def_readwrite("congestion_model_name", &tt_npe::npeConfig::congestion_model_name)
+        .def_readwrite("dram_controller_model", &tt_npe::npeConfig::dram_controller_model)
+        .def_readwrite(
+            "dram_controller_capacity_scale",
+            &tt_npe::npeConfig::dram_controller_capacity_scale)
         .def_readwrite("workload_json_filepath", &tt_npe::npeConfig::workload_json)
         .def_readwrite("cycles_per_timestep", &tt_npe::npeConfig::cycles_per_timestep)
         .def_readwrite("emit_timeline_file", &tt_npe::npeConfig::emit_timeline_file)

--- a/tt_npe/cpp/src/npeAPI.cpp
+++ b/tt_npe/cpp/src/npeAPI.cpp
@@ -24,6 +24,21 @@ void npeAPI::validateConfig() const {
             fmt::format(
                 "Illegal congestion model name '{}' in npeConfig", cfg.congestion_model_name));
     }
+    if (!npeConfig::isValidDramControllerModel(cfg.dram_controller_model)) {
+        throw npeException(
+            npeErrorCode::INVALID_CONFIG,
+            fmt::format(
+                "Illegal dram controller model '{}' in npeConfig; expected one of "
+                "'off', 'observe', 'enforce'",
+                cfg.dram_controller_model));
+    }
+    if (cfg.dram_controller_capacity_scale <= 0.0f) {
+        throw npeException(
+            npeErrorCode::INVALID_CONFIG,
+            fmt::format(
+                "Illegal dram controller capacity scale '{}' in npeConfig; must be > 0",
+                cfg.dram_controller_capacity_scale));
+    }
 }
 
 npeWorkload npeAPI::preprocessWorkload(npeWorkload wl) const {

--- a/tt_npe/cpp/src/npeEngine.cpp
+++ b/tt_npe/cpp/src/npeEngine.cpp
@@ -205,8 +205,14 @@ npeResult npeEngine::runSinglePerfSim(const npeWorkload &wl, const npeConfig &cf
 
     // setup congestion tracking data structures
     bool enable_congestion_model = cfg.congestion_model_name != "none";
+    // per-DRAM-controller congestion model; disabled unless explicitly requested, and
+    // inert whenever the base congestion model is off
+    DramCongestionParams dram_params = cfg.getDramCongestionParams();
+    if (!enable_congestion_model) {
+        dram_params.mode = DramCongestionMode::Off;
+    }
     // Initialize device state with appropriate dimensions for this device model
-    auto device_state = model->initDeviceState();
+    auto device_state = model->initDeviceState(dram_params.enabled());
 
     // create flattened list of transfers from workload
     auto transfer_state = initTransferState(wl);
@@ -261,14 +267,17 @@ npeResult npeEngine::runSinglePerfSim(const npeWorkload &wl, const npeConfig &cf
             transfer_state,
             live_transfer_ids,
             *device_state,
-            enable_congestion_model);
-        
+            enable_congestion_model,
+            dram_params);
+
         // update stats
         updateSimulationStats(
             *model,
             device_state->getLinkDemandGrid(),
             device_state->getMulticastWriteLinkDemandGrid(),
             device_state->getNIUDemandGrid(),
+            device_state->getDramDemandGrid(),
+            model->getDRAMControllerCongestionCapacity(dram_params.capacity_scale),
             live_transfer_ids,
             stats
         );

--- a/tt_npe/cpp/src/npeStats.cpp
+++ b/tt_npe/cpp/src/npeStats.cpp
@@ -97,6 +97,14 @@ std::string npeStats::deviceStats::to_string(bool verbose) const {
     output.append(fmt::format("       DRAM BW Util: {:5.1f}% (using golden)\n", dram_bw_util));
     output.append(fmt::format("       DRAM BW Util: {:5.1f}% (using estimated)\n", dram_bw_util_sim));
     output.append(fmt::format("        ETH BW Util: {:5.1f}%\n", getAggregateEthBwUtil()));
+    if (dram_controller_capacity > 0) {
+        output.append(
+            fmt::format(
+                "  DRAM ctrl demand: peak {:5.1f}%  avg {:5.1f}%\n",
+                overall_max_dram_controller_demand,
+                overall_avg_dram_controller_demand));
+        output.append(fmt::format("     DRAM hotspots: {}\n", getDRAMHotspotStr()));
+    }
     output.append("\n");
     output.append(fmt::format("      avg Link util: {:5.1f}%\n", overall_avg_link_util));
     output.append(
@@ -186,8 +194,10 @@ void npeStats::deviceStats::computeSummaryStats(const npeWorkload& wl, const npe
 
     for (auto [controller, dram_tx_bytes]: dram_tx_bytes_per_controller) {
         double dram_bandwidth_per_controller_over_golden_cycles = golden_cycles * device_model.getDRAMBandwidthPerController();
-        this->dram_bw_util_per_controller[controller] = (dram_tx_bytes / dram_bandwidth_per_controller_over_golden_cycles) * 100;    
+        this->dram_bw_util_per_controller[controller] = (dram_tx_bytes / dram_bandwidth_per_controller_over_golden_cycles) * 100;
     }
+
+    computeDramControllerStats(device_model, device_id);
 
     // compute eth bw utilization per core
     std::unordered_map<Coord, size_t> eth_tx_bytes_per_core;
@@ -938,6 +948,146 @@ double npeStats::deviceStats::getAggregateEthBwUtil() const {
         sum += util;
     }
     return sum / eth_bw_util_per_core.size();
+}
+
+//---- per-DRAM-controller congestion stats -----------------------------------------
+
+void npeStats::deviceStats::computeDramControllerStats(
+    const npeDeviceModel& device_model, DeviceID device_id) {
+    // no-op unless the DRAM controller model produced demand grids
+    if (dram_controller_capacity <= 0) {
+        return;
+    }
+
+    const size_t num_controllers = device_model.getNumDramControllers();
+    if (num_controllers == 0) {
+        return;
+    }
+
+    // running peak / sum / saturated-count per grid slot
+    std::unordered_map<uint32_t, double> peak;
+    std::unordered_map<uint32_t, double> sum;
+    std::unordered_map<uint32_t, size_t> saturated_timesteps;
+    size_t num_timesteps = 0;
+
+    for (const auto& ts : per_timestep_stats) {
+        if (ts.dram_demand_grid.empty()) {
+            continue;
+        }
+        num_timesteps++;
+        for (size_t slot = 0; slot < ts.dram_demand_grid.size(); slot++) {
+            // slot is flattened as (device_id * num_controllers + controller_id)
+            DeviceID slot_device_id = DeviceID(slot / num_controllers);
+            if (device_id != MESH_DEVICE && slot_device_id != device_id) {
+                continue;
+            }
+            uint32_t key = device_id == MESH_DEVICE ? uint32_t(slot)
+                                                    : uint32_t(slot % num_controllers);
+            double demand = ts.dram_demand_grid[slot];
+            auto& p = peak[key];
+            p = std::max(p, demand);
+            sum[key] += demand;
+            if (demand >= dram_controller_capacity) {
+                saturated_timesteps[key]++;
+            }
+        }
+    }
+
+    if (num_timesteps == 0) {
+        return;
+    }
+
+    dram_num_controllers = num_controllers;
+    dram_stats_device_id = device_id;
+
+    double demand_to_pct = 100.0 / dram_controller_capacity;
+    double summed_mean_pct = 0;
+    for (const auto& [key, peak_demand] : peak) {
+        double peak_pct = peak_demand * demand_to_pct;
+        double mean_pct = (sum[key] / double(num_timesteps)) * demand_to_pct;
+        dram_controller_peak_demand[key] = peak_pct;
+        dram_controller_mean_demand[key] = mean_pct;
+        dram_controller_saturated_frac[key] =
+            double(saturated_timesteps[key]) / double(num_timesteps);
+        overall_max_dram_controller_demand =
+            std::max(overall_max_dram_controller_demand, peak_pct);
+        summed_mean_pct += mean_pct;
+    }
+    if (!peak.empty()) {
+        overall_avg_dram_controller_demand = summed_mean_pct / double(peak.size());
+    }
+}
+
+std::string DramHotspot::to_string() const {
+    return fmt::format(
+        "d{}c{} peak={:.1f}% mean={:.1f}% sat={:.0f}%",
+        device_id,
+        controller_id,
+        peak_demand_pct,
+        mean_demand_pct,
+        saturated_frac * 100.0);
+}
+
+std::vector<DramHotspot> npeStats::deviceStats::getDRAMHotspots(double threshold_pct) const {
+    std::vector<DramHotspot> hotspots;
+    for (const auto& [key, peak_pct] : dram_controller_peak_demand) {
+        if (peak_pct < threshold_pct) {
+            continue;
+        }
+        DramHotspot hs;
+        // For a single-device deviceStats the key is the controller ID directly; for
+        // MESH_DEVICE it is the flattened slot, so decompose it back.
+        if (dram_stats_device_id == MESH_DEVICE && dram_num_controllers > 0) {
+            hs.controller_id = uint32_t(key % dram_num_controllers);
+            hs.device_id = DeviceID(key / dram_num_controllers);
+        } else {
+            hs.controller_id = key;
+            hs.device_id = dram_stats_device_id;
+        }
+        hs.peak_demand_pct = peak_pct;
+        auto mean_it = dram_controller_mean_demand.find(key);
+        if (mean_it != dram_controller_mean_demand.end()) {
+            hs.mean_demand_pct = mean_it->second;
+        }
+        auto sat_it = dram_controller_saturated_frac.find(key);
+        if (sat_it != dram_controller_saturated_frac.end()) {
+            hs.saturated_frac = sat_it->second;
+        }
+        hs.saturated_cycles = hs.saturated_frac * double(estimated_cycles);
+        hotspots.push_back(hs);
+    }
+    std::sort(hotspots.begin(), hotspots.end(), [](const auto& a, const auto& b) {
+        if (a.saturated_frac != b.saturated_frac) {
+            return a.saturated_frac > b.saturated_frac;
+        }
+        if (a.peak_demand_pct != b.peak_demand_pct) {
+            return a.peak_demand_pct > b.peak_demand_pct;
+        }
+        return a.controller_id < b.controller_id;
+    });
+    return hotspots;
+}
+
+std::string npeStats::deviceStats::getDRAMHotspotStr() const {
+    auto hotspots = getDRAMHotspots();
+    if (hotspots.empty()) {
+        return "-";
+    }
+    std::string result;
+    for (const auto& hs : hotspots) {
+        if (!result.empty()) result += " | ";
+        result += hs.to_string();
+    }
+    return result;
+}
+
+bool npeStats::deviceStats::isDRAMBound() const {
+    for (const auto& [key, frac] : dram_controller_saturated_frac) {
+        if (frac > 0.5) {
+            return true;
+        }
+    }
+    return false;
 }
 
 }  // namespace tt_npe

--- a/tt_npe/cpp/test/test_npe_dram_controller.cpp
+++ b/tt_npe/cpp/test/test_npe_dram_controller.cpp
@@ -1,0 +1,517 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Tenstorrent AI ULC
+
+// Tests for the per-DRAM-controller congestion model (npeConfig::dram_controller_model).
+//
+// The model has three modes and the tests below are organized around the invariants each
+// one must satisfy:
+//   off     (default) : no grid is allocated; every new stat is inert and cycle counts are
+//                       whatever they were before the feature existed.
+//   observe           : demand is accumulated and reported but never derates, so cycle
+//                       counts must be *identical* to off.
+//   enforce           : demand additionally derates bandwidth, so an oversubscribed
+//                       controller must lengthen the estimated runtime.
+
+#include <algorithm>
+#include <vector>
+
+#include "device_models/blackhole.hpp"
+#include "device_models/blackhole_multichip.hpp"
+#include "device_models/wormhole_b0.hpp"
+#include "device_models/wormhole_multichip.hpp"
+#include "gtest/gtest.h"
+#include "npeAPI.hpp"
+#include "npeCommon.hpp"
+#include "npeConfig.hpp"
+#include "npeDeviceModelFactory.hpp"
+#include "npeWorkload.hpp"
+
+namespace tt_npe {
+namespace {
+
+//---- helpers ---------------------------------------------------------------------------
+
+// Every DRAM coordinate known to a model, gathered by scanning the grid.
+std::vector<Coord> collectDramCoords(const npeDeviceModel &model, DeviceID device_id) {
+    std::vector<Coord> coords;
+    for (int r = 0; r < int(model.getRows()); r++) {
+        for (int c = 0; c < int(model.getCols()); c++) {
+            Coord coord{device_id, r, c};
+            if (model.getCoreType(coord) == CoreType::DRAM) {
+                coords.push_back(coord);
+            }
+        }
+    }
+    return coords;
+}
+
+struct SrcDstPair {
+    Coord src;
+    Coord dst;
+};
+
+// Builds a workload of concurrent DRAM->WORKER reads, one transfer per pair, all starting
+// at cycle 0 so they contend for the whole simulation.
+npeWorkload makeDramReadWorkload(const std::vector<SrcDstPair> &pairs, uint32_t num_packets = 512) {
+    npeWorkload wl;
+    npeWorkloadPhase phase;
+    for (const auto &p : pairs) {
+        phase.transfers.push_back(
+            npeWorkloadTransfer(
+                8192,
+                num_packets,
+                p.src,
+                p.dst,
+                0.0f,  // injection rate is inferred from src core type
+                0,
+                nocType::NOC0));
+    }
+    wl.addPhase(phase);
+    // golden cycles are only used for the post-hoc *_util reporting fields, not for the sim
+    wl.setGoldenResultCycles({{0, {0, 32}}});
+    return wl;
+}
+
+// Blackhole P150 controller 0 is shared by DRAM coords (0,0), (1,0) and (11,0). Each of
+// those NIUs can inject 40 B/cyc while the controller behind them is also rated 40 B/cyc,
+// so three concurrent reads demand 300% of the controller.
+//
+// Destinations are picked so the three NOC0 routes (east along the source row, then south)
+// share no link and no sink NIU. The DRAM controller is therefore the *only* resource the
+// three transfers contend for, which is what makes "enforce lengthens the run" attributable
+// to the controller term alone.
+std::vector<SrcDstPair> blackholeHotController0Pairs(DeviceID device_id = 0) {
+    return {
+        {Coord{device_id, 0, 0}, Coord{device_id, 2, 3}},
+        {Coord{device_id, 1, 0}, Coord{device_id, 3, 4}},
+        {Coord{device_id, 11, 0}, Coord{device_id, 11, 5}},
+    };
+}
+
+// One DRAM source per controller, each reading into a worker in its own row. No controller
+// sees more than a single NIU's worth of demand, so the controller term must stay inert.
+std::vector<SrcDstPair> blackholeSpreadPairs() {
+    return {
+        {Coord{0, 11, 0}, Coord{0, 11, 3}},    // controller 0
+        {Coord{0, 2, 0}, Coord{0, 2, 3}},      // controller 1
+        {Coord{0, 9, 0}, Coord{0, 9, 3}},      // controller 2
+        {Coord{0, 5, 0}, Coord{0, 5, 3}},      // controller 3
+        {Coord{0, 11, 9}, Coord{0, 11, 12}},   // controller 4
+        {Coord{0, 2, 9}, Coord{0, 2, 12}},     // controller 5
+        {Coord{0, 9, 9}, Coord{0, 9, 12}},     // controller 6
+        {Coord{0, 5, 9}, Coord{0, 5, 12}},     // controller 7
+    };
+}
+
+npeConfig makeConfig(
+    const std::string &device_name, const std::string &dram_model, float capacity_scale = 1.0f) {
+    npeConfig cfg;
+    cfg.device_name = device_name;
+    cfg.congestion_model_name = "fast";
+    cfg.cycles_per_timestep = 32;
+    cfg.dram_controller_model = dram_model;
+    cfg.dram_controller_capacity_scale = capacity_scale;
+    return cfg;
+}
+
+npeStats runOrFail(const npeConfig &cfg, const npeWorkload &wl) {
+    npeAPI api(cfg);
+    auto result = api.runNPE(wl);
+    EXPECT_TRUE(std::holds_alternative<npeStats>(result));
+    return std::get<npeStats>(result);
+}
+
+const npeStats::deviceStats &meshStats(const npeStats &stats) {
+    return stats.per_device_stats.at(MESH_DEVICE);
+}
+
+}  // namespace
+
+//---- grid sizing / ID mapping -----------------------------------------------------------
+
+TEST(npeDramControllerTest, BlackholeGridSizingCoversEveryControllerID) {
+    BlackholeDeviceModel model(BlackholeDeviceModel::DRAMHarvestingConfig::NO_HARVESTING);
+
+    EXPECT_EQ(model.getNumDramControllers(), 8u);
+    EXPECT_EQ(model.getNumDramDemandSlots(), 8u);
+
+    // getDRAMBandwidthPerChip() == NUM_DRAM_CONTROLLERS * per-controller BW, so this pins
+    // the (private) aggregate-bandwidth constant at 8 for the unharvested part.
+    EXPECT_NEAR(model.getDRAMBandwidthPerChip() / model.getDRAMBandwidthPerController(), 8.0, 1e-4);
+
+    for (const auto &coord : collectDramCoords(model, model.getDeviceID())) {
+        EXPECT_LT(model.getDramDemandID(coord), model.getNumDramDemandSlots())
+            << "coord (" << coord.row << "," << coord.col << ") maps out of grid bounds";
+    }
+}
+
+// The edge case the feature explicitly guards: under SINGLE_BANK_HARVESTING the model's
+// NUM_DRAM_CONTROLLERS constant drops to 7, but dram_coord_to_controller_map still emits
+// IDs 0..7. Sizing the demand grid off the constant would be an out-of-bounds write on
+// controller 7, so getNumDramControllers() must report the coordinate map's 8.
+TEST(npeDramControllerTest, BlackholeHarvestedGridSizingIsNotNumDramControllersConstant) {
+    BlackholeDeviceModel harvested(
+        BlackholeDeviceModel::DRAMHarvestingConfig::SINGLE_BANK_HARVESTING);
+
+    // aggregate-bandwidth constant really is 7 under harvesting ...
+    EXPECT_NEAR(
+        harvested.getDRAMBandwidthPerChip() / harvested.getDRAMBandwidthPerController(),
+        7.0,
+        1e-4);
+    // ... while the coordinate map still emits controller ID 7, so the grid must hold 8.
+    EXPECT_EQ(harvested.getDramControllerIDForCore(Coord{harvested.getDeviceID(), 5, 9}), 7u);
+    EXPECT_EQ(harvested.getNumDramControllers(), 8u);
+    EXPECT_EQ(harvested.getNumDramDemandSlots(), 8u);
+
+    for (const auto &coord : collectDramCoords(harvested, harvested.getDeviceID())) {
+        EXPECT_LT(harvested.getDramDemandID(coord), harvested.getNumDramDemandSlots());
+    }
+}
+
+TEST(npeDramControllerTest, WormholeGridSizingCoversEveryControllerID) {
+    WormholeB0DeviceModel model;
+
+    EXPECT_EQ(model.getNumDramControllers(), 6u);
+    EXPECT_EQ(model.getNumDramDemandSlots(), 6u);
+    for (const auto &coord : collectDramCoords(model, model.getDeviceID())) {
+        EXPECT_LT(model.getDramDemandID(coord), model.getNumDramDemandSlots());
+    }
+}
+
+// getDramControllerIDForCore() on the multichip models delegates to their single-chip
+// member, whose coordinate map hardcodes device_id 0. Without the explicit device_id stride
+// in getDramDemandID() every chip would alias onto chip 0's slots.
+template <typename ModelT>
+void checkMultichipDemandIDsDoNotCollide(const ModelT &model) {
+    const size_t per_chip = model.getNumDramControllers();
+    ASSERT_GT(per_chip, 0u);
+    EXPECT_EQ(model.getNumDramDemandSlots(), model.getNumChips() * per_chip);
+
+    std::vector<bool> slot_seen(model.getNumDramDemandSlots(), false);
+    for (size_t dev = 0; dev < model.getNumChips(); dev++) {
+        const auto device_id = DeviceID(dev);
+        auto dram_coords = collectDramCoords(model, device_id);
+        ASSERT_FALSE(dram_coords.empty());
+        for (const auto &coord : dram_coords) {
+            size_t slot = model.getDramDemandID(coord);
+            ASSERT_LT(slot, model.getNumDramDemandSlots());
+            // slot must live in this chip's band
+            EXPECT_EQ(slot / per_chip, dev) << "controller ID collided across chips";
+            // the same (row,col) on chip N must be exactly N bands above chip 0
+            EXPECT_EQ(
+                slot,
+                dev * per_chip + model.getDramDemandID(Coord{DeviceID(0), coord.row, coord.col}));
+            slot_seen[slot] = true;
+        }
+    }
+    EXPECT_TRUE(std::all_of(slot_seen.begin(), slot_seen.end(), [](bool b) { return b; }))
+        << "some demand grid slots are unreachable from any DRAM coord";
+}
+
+TEST(npeDramControllerTest, WormholeMultichipDemandIDsDoNotCollideAcrossChips) {
+    WormholeMultichipDeviceModel model(4);
+    checkMultichipDemandIDsDoNotCollide(model);
+}
+
+TEST(npeDramControllerTest, BlackholeMultichipDemandIDsDoNotCollideAcrossChips) {
+    BlackholeMultichipDeviceModel model(2);
+    checkMultichipDemandIDsDoNotCollide(model);
+}
+
+// initDeviceState() defaults to *not* allocating the grid; an empty grid is what
+// short-circuits every new code path inside modelCongestion.
+TEST(npeDramControllerTest, InitDeviceStateOnlyAllocatesGridWhenRequested) {
+    std::vector<std::string> device_names = {"wormhole_b0", "P150", "blackhole", "T3K", "P300"};
+    for (const auto &name : device_names) {
+        auto model = npeDeviceModelFactory::createDeviceModel(name);
+
+        auto default_state = model->initDeviceState();
+        EXPECT_TRUE(default_state->getDramDemandGrid().empty()) << "device " << name;
+
+        auto disabled_state = model->initDeviceState(false);
+        EXPECT_TRUE(disabled_state->getDramDemandGrid().empty()) << "device " << name;
+
+        auto enabled_state = model->initDeviceState(true);
+        EXPECT_EQ(enabled_state->getDramDemandGrid().size(), model->getNumDramDemandSlots())
+            << "device " << name;
+    }
+}
+
+//---- config plumbing --------------------------------------------------------------------
+
+TEST(npeDramControllerTest, ConfigTranslatesTriStateFlag) {
+    npeConfig cfg;
+    EXPECT_EQ(cfg.dram_controller_model, "off");
+    EXPECT_FALSE(cfg.getDramCongestionParams().enabled());
+    EXPECT_FALSE(cfg.getDramCongestionParams().enforcing());
+
+    cfg.dram_controller_model = "observe";
+    EXPECT_TRUE(cfg.getDramCongestionParams().enabled());
+    EXPECT_FALSE(cfg.getDramCongestionParams().enforcing());
+
+    cfg.dram_controller_model = "enforce";
+    EXPECT_TRUE(cfg.getDramCongestionParams().enabled());
+    EXPECT_TRUE(cfg.getDramCongestionParams().enforcing());
+
+    cfg.dram_controller_capacity_scale = 2.5f;
+    EXPECT_FLOAT_EQ(cfg.getDramCongestionParams().capacity_scale, 2.5f);
+}
+
+TEST(npeDramControllerTest, RejectsInvalidDramControllerModel) {
+    // a typo must be a hard error rather than a silently disabled feature
+    EXPECT_THROW(npeAPI api(makeConfig("P150", "enfroce")), npeException);
+    EXPECT_THROW(npeAPI api(makeConfig("P150", "")), npeException);
+    EXPECT_NO_THROW(npeAPI api(makeConfig("P150", "off")));
+    EXPECT_NO_THROW(npeAPI api(makeConfig("P150", "observe")));
+    EXPECT_NO_THROW(npeAPI api(makeConfig("P150", "enforce")));
+}
+
+TEST(npeDramControllerTest, RejectsNonPositiveCapacityScale) {
+    EXPECT_THROW(npeAPI api(makeConfig("P150", "enforce", 0.0f)), npeException);
+    EXPECT_THROW(npeAPI api(makeConfig("P150", "enforce", -1.0f)), npeException);
+}
+
+//---- end-to-end behavior ----------------------------------------------------------------
+
+// (a) default-off back-compat: none of the new state exists unless asked for.
+TEST(npeDramControllerTest, DefaultOffLeavesAllNewStatsInert) {
+    auto wl = makeDramReadWorkload(blackholeHotController0Pairs());
+
+    npeConfig cfg;
+    cfg.device_name = "P150";
+    cfg.cycles_per_timestep = 32;
+    // deliberately *not* touching dram_controller_model -- this is the shipped default
+    ASSERT_EQ(cfg.dram_controller_model, "off");
+
+    auto stats = runOrFail(cfg, wl);
+    const auto &ds = meshStats(stats);
+
+    EXPECT_DOUBLE_EQ(ds.dram_controller_capacity, 0.0);
+    EXPECT_DOUBLE_EQ(ds.overall_max_dram_controller_demand, 0.0);
+    EXPECT_DOUBLE_EQ(ds.overall_avg_dram_controller_demand, 0.0);
+    EXPECT_TRUE(ds.dram_controller_peak_demand.empty());
+    EXPECT_TRUE(ds.dram_controller_mean_demand.empty());
+    EXPECT_TRUE(ds.dram_controller_saturated_frac.empty());
+    EXPECT_EQ(ds.dram_num_controllers, 0u);
+    EXPECT_TRUE(ds.getDRAMHotspots().empty());
+    EXPECT_EQ(ds.getDRAMHotspotStr(), "-");
+    EXPECT_FALSE(ds.isDRAMBound());
+
+    // the per-timestep grid is never allocated either
+    ASSERT_FALSE(ds.per_timestep_stats.empty());
+    for (const auto &ts : ds.per_timestep_stats) {
+        EXPECT_TRUE(ts.dram_demand_grid.empty());
+    }
+
+    // and the post-hoc DRAM reporting that predates this feature is still produced
+    EXPECT_FALSE(ds.dram_bw_util_per_controller.empty());
+}
+
+// (b) observe accumulates and reports but must not move a single cycle.
+TEST(npeDramControllerTest, ObserveReportsWithoutChangingCycles) {
+    auto wl = makeDramReadWorkload(blackholeHotController0Pairs());
+
+    auto off = runOrFail(makeConfig("P150", "off"), wl);
+    auto observe = runOrFail(makeConfig("P150", "observe"), wl);
+
+    EXPECT_EQ(meshStats(observe).estimated_cycles, meshStats(off).estimated_cycles);
+    EXPECT_DOUBLE_EQ(meshStats(observe).dram_bw_util_sim, meshStats(off).dram_bw_util_sim);
+
+    const auto &ds = meshStats(observe);
+    // 40 B/cyc per controller on Blackhole; the scale factor is 1.0 here
+    EXPECT_GT(ds.dram_controller_capacity, 0.0);
+    ASSERT_TRUE(ds.dram_controller_peak_demand.contains(0u));
+    // three 40 B/cyc DRAM NIUs behind one 40 B/cyc controller
+    EXPECT_GT(ds.dram_controller_peak_demand.at(0u), 100.0);
+    EXPECT_GT(ds.overall_max_dram_controller_demand, 100.0);
+    EXPECT_TRUE(ds.isDRAMBound());
+
+    auto hotspots = ds.getDRAMHotspots();
+    ASSERT_FALSE(hotspots.empty());
+    EXPECT_EQ(hotspots.front().controller_id, 0u);
+    EXPECT_GT(hotspots.front().peak_demand_pct, 100.0);
+    EXPECT_NE(ds.getDRAMHotspotStr(), "-");
+
+    // controllers that saw no traffic must not be reported as hotspots
+    for (const auto &hs : hotspots) {
+        EXPECT_EQ(hs.controller_id, 0u) << "unexpected hotspot on an idle controller";
+    }
+}
+
+// (c) enforce must actually derate an oversubscribed controller.
+TEST(npeDramControllerTest, EnforceDeratesOversubscribedController) {
+    auto wl = makeDramReadWorkload(blackholeHotController0Pairs());
+
+    auto off = runOrFail(makeConfig("P150", "off"), wl);
+    auto observe = runOrFail(makeConfig("P150", "observe"), wl);
+    auto enforce = runOrFail(makeConfig("P150", "enforce"), wl);
+
+    const auto &off_ds = meshStats(off);
+    const auto &obs_ds = meshStats(observe);
+    const auto &en_ds = meshStats(enforce);
+
+    EXPECT_GT(en_ds.estimated_cycles, off_ds.estimated_cycles)
+        << "enforce did not derate a 3x oversubscribed DRAM controller";
+
+    // Three 40 B/cyc NIUs behind one 40 B/cyc controller: the run should stretch by roughly
+    // 3x, which is the whole point of modelling the controller.
+    const double stretch = double(en_ds.estimated_cycles) / double(off_ds.estimated_cycles);
+    EXPECT_NEAR(stretch, 3.0, 0.35) << "observed stretch factor " << stretch;
+
+    // The reported demand is *offered* demand: like the pre-existing link and NIU demand
+    // grids it is sampled from the un-derated bandwidths at the top of each timestep, so it
+    // reads the same 3x in observe and enforce. The difference between the modes shows up in
+    // estimated_cycles, not in the demand numbers.
+    ASSERT_TRUE(en_ds.dram_controller_peak_demand.contains(0u));
+    ASSERT_TRUE(obs_ds.dram_controller_peak_demand.contains(0u));
+    ASSERT_TRUE(en_ds.dram_controller_mean_demand.contains(0u));
+    EXPECT_GT(en_ds.dram_controller_peak_demand.at(0u), 100.0);
+    EXPECT_GT(en_ds.dram_controller_mean_demand.at(0u), 100.0);
+    EXPECT_DOUBLE_EQ(
+        en_ds.dram_controller_peak_demand.at(0u), obs_ds.dram_controller_peak_demand.at(0u));
+
+    auto hotspots = en_ds.getDRAMHotspots();
+    ASSERT_FALSE(hotspots.empty());
+    EXPECT_EQ(hotspots.front().controller_id, 0u);
+    EXPECT_EQ(hotspots.front().device_id, 0);
+    EXPECT_GT(hotspots.front().saturated_frac, 0.5);
+    EXPECT_GT(hotspots.front().saturated_cycles, 0.0);
+    EXPECT_TRUE(en_ds.isDRAMBound());
+}
+
+// The controller term is the *only* thing separating enforce from off: scale the capacity
+// far past anything the workload can demand and enforce must collapse back onto off.
+TEST(npeDramControllerTest, EnforceWithUnreachableCapacityMatchesOff) {
+    auto wl = makeDramReadWorkload(blackholeHotController0Pairs());
+
+    auto off = runOrFail(makeConfig("P150", "off"), wl);
+    auto enforce_loose = runOrFail(makeConfig("P150", "enforce", 8.0f), wl);
+
+    EXPECT_EQ(meshStats(enforce_loose).estimated_cycles, meshStats(off).estimated_cycles);
+    // reporting is still produced, just scaled against the inflated capacity
+    EXPECT_GT(meshStats(enforce_loose).dram_controller_capacity, 0.0);
+    EXPECT_LT(meshStats(enforce_loose).overall_max_dram_controller_demand, 100.0);
+}
+
+// A workload that spreads its DRAM traffic one NIU per controller leaves every controller
+// at or below capacity, so enforce must not lengthen it.
+TEST(npeDramControllerTest, EnforceDoesNotPenalizeSpreadDramTraffic) {
+    auto wl = makeDramReadWorkload(blackholeSpreadPairs());
+
+    auto off = runOrFail(makeConfig("P150", "off"), wl);
+    auto observe = runOrFail(makeConfig("P150", "observe"), wl);
+    auto enforce = runOrFail(makeConfig("P150", "enforce"), wl);
+
+    // no controller is oversubscribed
+    EXPECT_LE(meshStats(observe).overall_max_dram_controller_demand, 101.0);
+    EXPECT_TRUE(meshStats(observe).getDRAMHotspots(150.0).empty());
+
+    EXPECT_EQ(meshStats(enforce).estimated_cycles, meshStats(off).estimated_cycles);
+}
+
+// (d) regression for the Blackhole SINGLE_BANK_HARVESTING out-of-bounds case: "blackhole" /
+// "P100" build the harvested model whose NUM_DRAM_CONTROLLERS is 7, while controller ID 7 is
+// still reachable from coords (5,9)/(6,9)/(7,9). A grid sized 7 would be written past its
+// end here.
+TEST(npeDramControllerTest, HarvestedBlackholeHandlesHighestControllerID) {
+    std::vector<SrcDstPair> pairs = {
+        {Coord{0, 5, 9}, Coord{0, 5, 12}},
+        {Coord{0, 6, 9}, Coord{0, 6, 12}},
+        {Coord{0, 7, 9}, Coord{0, 7, 12}},
+    };
+    auto wl = makeDramReadWorkload(pairs);
+
+    auto off = runOrFail(makeConfig("blackhole", "off"), wl);
+    auto enforce = runOrFail(makeConfig("blackhole", "enforce"), wl);
+
+    const auto &en_ds = meshStats(enforce);
+    ASSERT_TRUE(en_ds.dram_controller_peak_demand.contains(7u))
+        << "controller 7 never appeared in the demand grid";
+    EXPECT_GT(en_ds.dram_controller_peak_demand.at(7u), 100.0);
+    EXPECT_GT(en_ds.estimated_cycles, meshStats(off).estimated_cycles);
+
+    auto hotspots = en_ds.getDRAMHotspots();
+    ASSERT_FALSE(hotspots.empty());
+    EXPECT_EQ(hotspots.front().controller_id, 7u);
+}
+
+// (d) multichip: hot controller 0 lives on chip 1, so the MESH_DEVICE grid key must be
+// (1 * num_controllers + 0) and the hotspot must decompose back to device 1 / controller 0.
+TEST(npeDramControllerTest, MultichipHotspotIsAttributedToTheRightChip) {
+    constexpr DeviceID kHotDevice = 1;
+    auto wl = makeDramReadWorkload(blackholeHotController0Pairs(kHotDevice));
+    // every device the model knows about needs a golden cycle entry
+    wl.setGoldenResultCycles({{0, {0, 32}}, {kHotDevice, {0, 32}}});
+
+    auto off = runOrFail(makeConfig("P300", "off"), wl);
+    auto enforce = runOrFail(makeConfig("P300", "enforce"), wl);
+    EXPECT_GT(meshStats(enforce).estimated_cycles, meshStats(off).estimated_cycles);
+
+    npeAPI api(makeConfig("P300", "enforce"));
+    const size_t num_controllers = api.getDeviceModel().getNumDramControllers();
+
+    // mesh-level view: keys are flattened grid slots
+    const auto &mesh = meshStats(enforce);
+    const uint32_t expected_slot = uint32_t(kHotDevice * num_controllers + 0);
+    ASSERT_TRUE(mesh.dram_controller_peak_demand.contains(expected_slot));
+    EXPECT_GT(mesh.dram_controller_peak_demand.at(expected_slot), 100.0);
+    // chip 0's controller 0 slot exists but must be idle -- if the device_id stride were
+    // missing, chip 1's traffic would have landed here instead
+    ASSERT_TRUE(mesh.dram_controller_peak_demand.contains(0u));
+    EXPECT_DOUBLE_EQ(mesh.dram_controller_peak_demand.at(0u), 0.0)
+        << "chip 0 controller 0 saw traffic that belongs to chip 1";
+
+    auto mesh_hotspots = mesh.getDRAMHotspots();
+    ASSERT_FALSE(mesh_hotspots.empty());
+    EXPECT_EQ(mesh_hotspots.front().device_id, kHotDevice);
+    EXPECT_EQ(mesh_hotspots.front().controller_id, 0u);
+
+    // per-device view: keys are plain controller IDs
+    ASSERT_TRUE(enforce.per_device_stats.contains(kHotDevice));
+    const auto &dev = enforce.per_device_stats.at(kHotDevice);
+    ASSERT_TRUE(dev.dram_controller_peak_demand.contains(0u));
+    EXPECT_GT(dev.dram_controller_peak_demand.at(0u), 100.0);
+    auto dev_hotspots = dev.getDRAMHotspots();
+    ASSERT_FALSE(dev_hotspots.empty());
+    EXPECT_EQ(dev_hotspots.front().device_id, kHotDevice);
+    EXPECT_EQ(dev_hotspots.front().controller_id, 0u);
+}
+
+// The DRAM controller model is a refinement of the congestion model; with congestion
+// modelling switched off entirely it must stay inert.
+TEST(npeDramControllerTest, InertWhenBaseCongestionModelIsDisabled) {
+    auto wl = makeDramReadWorkload(blackholeHotController0Pairs());
+
+    auto cfg = makeConfig("P150", "enforce");
+    cfg.congestion_model_name = "none";
+    auto no_cong_enforce = runOrFail(cfg, wl);
+
+    cfg.dram_controller_model = "off";
+    auto no_cong_off = runOrFail(cfg, wl);
+
+    EXPECT_EQ(
+        meshStats(no_cong_enforce).estimated_cycles, meshStats(no_cong_off).estimated_cycles);
+    EXPECT_DOUBLE_EQ(meshStats(no_cong_enforce).dram_controller_capacity, 0.0);
+    EXPECT_TRUE(meshStats(no_cong_enforce).dram_controller_peak_demand.empty());
+}
+
+// Wormhole carries the same feature through a separate copy of modelCongestion; controller 0
+// there is shared by (0,0), (1,0) and (11,0).
+TEST(npeDramControllerTest, WormholeEnforceDeratesOversubscribedController) {
+    std::vector<SrcDstPair> pairs = {
+        {Coord{0, 0, 0}, Coord{0, 2, 3}},
+        {Coord{0, 1, 0}, Coord{0, 3, 4}},
+        {Coord{0, 11, 0}, Coord{0, 11, 6}},
+    };
+    auto wl = makeDramReadWorkload(pairs);
+
+    auto off = runOrFail(makeConfig("wormhole_b0", "off"), wl);
+    auto observe = runOrFail(makeConfig("wormhole_b0", "observe"), wl);
+    auto enforce = runOrFail(makeConfig("wormhole_b0", "enforce"), wl);
+
+    EXPECT_EQ(meshStats(observe).estimated_cycles, meshStats(off).estimated_cycles);
+    EXPECT_GT(meshStats(observe).overall_max_dram_controller_demand, 100.0);
+    EXPECT_GT(meshStats(enforce).estimated_cycles, meshStats(off).estimated_cycles);
+}
+
+}  // namespace tt_npe

--- a/tt_npe/py/pycli/tt_npe.py
+++ b/tt_npe/py/pycli/tt_npe.py
@@ -41,6 +41,29 @@ def parse_cli_args():
     )
 
     parser.add_argument(
+        "--dram-controller-model",
+        type=str,
+        default="off",
+        choices=["off", "observe", "enforce"],
+        help=(
+            "Per-DRAM-controller congestion model (default: 'off'). 'observe' reports "
+            "per-controller demand without derating bandwidth (cycle counts are identical "
+            "to 'off'); 'enforce' additionally derates transfers sharing an oversubscribed "
+            "DRAM controller"
+        ),
+    )
+
+    parser.add_argument(
+        "--dram-controller-capacity-scale",
+        type=float,
+        default=1.0,
+        help=(
+            "Scale the per-DRAM-controller bandwidth used by the congestion model only "
+            "(default: 1.0). Does not affect reported DRAM BW utilization"
+        ),
+    )
+
+    parser.add_argument(
         "-w", "--workload", type=str, default="", help="Run workload from JSON file"
     )
 
@@ -121,6 +144,8 @@ def main():
     cfg = npe.Config()
     cfg.device_name = args.device
     cfg.congestion_model_name = args.cong_model
+    cfg.dram_controller_model = args.dram_controller_model
+    cfg.dram_controller_capacity_scale = args.dram_controller_capacity_scale
     cfg.workload_json_filepath = args.workload
     cfg.workload_is_noc_trace = args.workload_is_noc_trace
     cfg.cycles_per_timestep = args.cycles_per_timestep

--- a/tt_npe/py/pytest/test_bindings.py
+++ b/tt_npe/py/pytest/test_bindings.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 import tt_npe_pybind as npe
+import pytest
 import random
 import pprint
 
@@ -110,3 +111,152 @@ def test_npe_create_and_run_larger_synthetic_workload():
     assert npe_api is not None
     result = npe_api.runNPE(wl)
     assert type(result) == npe.Stats
+
+
+#---- per-DRAM-controller congestion model -------------------------------------------
+
+# Blackhole P150 controller 0 is shared by DRAM coords (0,0), (1,0) and (11,0). Reading
+# from all three at once demands 3x the controller's bandwidth while every individual NIU
+# still looks unsaturated -- exactly what the per-controller model exists to catch.
+BH_HOT_CONTROLLER_PAIRS = [
+    ((0, 0), (2, 3)),
+    ((1, 0), (3, 4)),
+    ((11, 0), (11, 5)),
+]
+
+
+def _make_dram_hot_workload():
+    phase = npe.Phase()
+    for (src_row, src_col), (dst_row, dst_col) in BH_HOT_CONTROLLER_PAIRS:
+        phase.addTransfer(
+            npe.Transfer(
+                8192,
+                512,
+                npe.Coord(0, src_row, src_col),
+                npe.Coord(0, dst_row, dst_col),
+                0.0,
+                0,
+                npe.NocType.NOC_0,
+            )
+        )
+    wl = npe.Workload()
+    wl.addPhase(phase)
+    wl.setGoldenResultCycles({0: (0, 32)})
+    return wl
+
+
+def _make_dram_config(dram_controller_model, capacity_scale=1.0):
+    cfg = npe.Config()
+    cfg.device_name = "P150"
+    cfg.cycles_per_timestep = 32
+    cfg.dram_controller_model = dram_controller_model
+    cfg.dram_controller_capacity_scale = capacity_scale
+    return cfg
+
+
+def _run(cfg, wl):
+    npe_api = npe.InitAPI(cfg)
+    assert npe_api is not None
+    result = npe_api.runNPE(wl)
+    assert type(result) == npe.Stats
+    # MESH_DEVICE is keyed as -1
+    return result.per_device_stats[-1]
+
+
+def test_npe_dram_controller_config_fields():
+    cfg = npe.Config()
+    # default is "off" so existing predictions are unchanged
+    assert cfg.dram_controller_model == "off"
+    assert cfg.dram_controller_capacity_scale == 1.0
+
+    for mode in ("off", "observe", "enforce"):
+        cfg.dram_controller_model = mode
+        assert cfg.dram_controller_model == mode
+        assert npe.InitAPI(cfg) is not None
+
+    cfg.dram_controller_capacity_scale = 1.2
+    assert cfg.dram_controller_capacity_scale == pytest.approx(1.2)
+
+
+def test_npe_dram_controller_rejects_bad_config():
+    cfg = _make_dram_config("enfroce")
+    assert npe.InitAPI(cfg) is None
+
+    cfg = _make_dram_config("enforce", capacity_scale=0.0)
+    assert npe.InitAPI(cfg) is None
+
+
+def test_npe_dram_controller_default_off_is_inert():
+    stats = _run(_make_dram_config("off"), _make_dram_hot_workload())
+
+    assert stats.dram_controller_capacity == 0.0
+    assert stats.overall_max_dram_controller_demand == 0.0
+    assert stats.overall_avg_dram_controller_demand == 0.0
+    assert stats.dram_controller_peak_demand == {}
+    assert stats.dram_controller_mean_demand == {}
+    assert stats.dram_controller_saturated_frac == {}
+    assert stats.getDRAMHotspots() == []
+    assert stats.getDRAMHotspotStr() == "-"
+    assert stats.isDRAMBound() is False
+
+
+def test_npe_dram_controller_observe_reports_without_derating():
+    wl = _make_dram_hot_workload()
+    off = _run(_make_dram_config("off"), wl)
+    observe = _run(_make_dram_config("observe"), wl)
+
+    # observe accumulates and reports but must never move a cycle
+    assert observe.estimated_cycles == off.estimated_cycles
+
+    assert observe.dram_controller_capacity > 0.0
+    assert isinstance(observe.dram_controller_peak_demand, dict)
+    assert 0 in observe.dram_controller_peak_demand
+    assert observe.dram_controller_peak_demand[0] > 100.0
+    assert observe.overall_max_dram_controller_demand > 100.0
+    assert observe.isDRAMBound() is True
+
+    hotspots = observe.getDRAMHotspots()
+    assert len(hotspots) > 0
+    hs = hotspots[0]
+    assert isinstance(hs, npe.DramHotspot)
+    assert hs.controller_id == 0
+    assert hs.device_id == 0
+    assert hs.peak_demand_pct > 100.0
+    assert hs.mean_demand_pct > 100.0
+    assert 0.0 <= hs.saturated_frac <= 1.0
+    assert hs.saturated_cycles > 0.0
+    assert isinstance(str(hs), str) and str(hs) != ""
+
+    # threshold argument filters the list
+    assert observe.getDRAMHotspots(threshold_pct=1e6) == []
+    assert observe.getDRAMHotspotStr() != "-"
+
+
+def test_npe_dram_controller_enforce_derates():
+    wl = _make_dram_hot_workload()
+    off = _run(_make_dram_config("off"), wl)
+    enforce = _run(_make_dram_config("enforce"), wl)
+
+    assert enforce.estimated_cycles > off.estimated_cycles
+
+    # the capacity scale is a calibration knob for the congestion model only; scaling it
+    # past anything the workload can demand collapses enforce back onto off
+    loose = _run(_make_dram_config("enforce", capacity_scale=8.0), wl)
+    assert loose.estimated_cycles == off.estimated_cycles
+    # ... while post-hoc DRAM BW reporting is untouched by the scale factor
+    assert loose.dram_bw_util_per_controller == off.dram_bw_util_per_controller
+
+
+def test_npe_dram_controller_stats_survive_pickling():
+    import pickle
+
+    observe = _run(_make_dram_config("observe"), _make_dram_hot_workload())
+    restored = pickle.loads(pickle.dumps(observe))
+
+    assert restored.dram_controller_capacity == observe.dram_controller_capacity
+    assert restored.overall_max_dram_controller_demand == pytest.approx(
+        observe.overall_max_dram_controller_demand
+    )
+    assert restored.dram_controller_peak_demand == observe.dram_controller_peak_demand
+    assert restored.dram_controller_mean_demand == observe.dram_controller_mean_demand
+    assert restored.dram_controller_saturated_frac == observe.dram_controller_saturated_frac


### PR DESCRIPTION
## Problem

The congestion model derates only per-**link** and per-**NIU**. There is no per-DRAM-**controller** resource — `dram_bw_util*` is computed post-hoc in `computeSummaryStats` from the static workload and never feeds back into a derate.

But **3 DRAM NIU coords share each controller** on both arches (BH 24 coords / 8 controllers, WH 18 / 6), and each coord is further split into 4 demand-grid slots (NOC0/1 × SRC/SINK). So a controller can be 3× oversubscribed per NoC direction with **every individual NIU showing zero derate**.

This lets the model emit physically impossible schedules. A synthetic Blackhole trace aimed at one controller's three NIUs:

- runs at **119.1 B/cycle through a 40 B/cycle controller** — 2.98× over capacity, and within 0.7% of `3 × 40 = 120`, i.e. exactly the sum of the three NIUs' absorption rates, each pinned at 100% while the shared controller sat at 300%
- a spread variant reports **`dram_bw_util_sim = 212.6%`** — a schedule needing 2.1× more DRAM bandwidth than the chip physically has, with nothing in the model objecting

Wormhole reproduces the signature at 1.46×.

## Change

A `DramDemandGrid` in `npeDeviceState`, with one accumulate site and one derate site inside `modelCongestion`, mirroring the existing sink-NIU derate. Applied in **all four** device models (the two multichip models compose rather than inherit and carry duplicated congestion code; their existing drifts were preserved verbatim).

Plus per-controller peak/mean/saturation stats and `getDRAMHotspots()` / `getDRAMHotspotStr()` / `isDRAMBound()`, exposed through pybind and the CLI.

**Tri-state flag** `dram_controller_model`, not a boolean:

| mode | behavior |
|---|---|
| `off` **(default)** | grid size 0, every new path skipped — bit-identical to before |
| `observe` | accumulate + report, **no** derate — cycles identical to `off` |
| `enforce` | accumulate + report + derate |

Default is `off` deliberately: the per-controller capacity constant is unvalidated against silicon (see Caveats), and on-by-default would silently move published results.

Three hazards handled, each confirmed empirically:
1. `getNumDramControllers()` returns the distinct-ID count from the coord map, not `NUM_DRAM_CONTROLLERS` — under BH `SINGLE_BANK_HARVESTING` the latter is 7 while the map still emits IDs 0..7 (would be an OOB grid write).
2. `getDramDemandID()` carries an explicit `device_id` stride, because `getDramControllerIDForCore()` delegates to the single-chip model which hardcodes device 0 — IDs would otherwise collide across chips.
3. Derates compose with `std::min`, never a product — link/NIU/controller are nested resources, so `min()` takes the tightest and cannot double-count. Rationale is commented at the `min()` site in all four models.

Calibration is routed through a separate `getDRAMControllerCongestionCapacity(scale)` so it can never perturb the published post-hoc `dram_bw_util` / `dram_bw_util_per_controller` numbers.

## Validation

**Back-compat (the important one).** Snapshotted the pre-change `install/`, then compared 5 numeric columns across all 71 bundled traces = 355 cells:

- pre-change vs new/`off` → **0 / 355 differing cells**
- pre-change vs new/`observe` → **0 / 355 differing cells**
- pre-change vs new/`enforce` → 28 cells (7 traces)

`observe` matching exactly is the structural proof that the derate is the only write path to `curr_bandwidth`. Attribution control: `enforce` with `dram_controller_capacity_scale=8.0` (controller can never bind) → 0/71 traces differ from `off`, so the `enforce` deltas are attributable to the DRAM term alone.

**Feature works.** Synthetic BH trace, 24 workers × 16 × 8192 B, all NOC_0 reads at controller 0; analytic controller-limited floor = 78,643 cycles:

| mode | cycles | B/cycle | ctrl peak |
|---|---|---|---|
| `off` | 26,406 | 119.1 | 0.0% (invisible) |
| `observe` | 26,406 | 119.1 | 600%, sat 99% |
| `enforce` | **78,976** | 39.8 | 600%, sat 100% |

`enforce` lands **0.42% from the analytic floor**.

**Tests:** 24 new (18 gtest in `test_npe_dram_controller.cpp` + 6 pybind) covering default-off inertness, `observe == off`, `enforce` derate with a workload whose NOC0 routes share no link and no sink NIU (so the controller is the *only* contended resource), the harvesting and multichip-stride edge cases, and binding reachability. Suite: **63/63 C++** (was 45) and **16/16 pytest** from `tt_npe/`. All 71 bundled traces × 3 modes: 0 crashes.

**Docs:** new README section documenting the flag, the capacity scale, and how to read a hotspot line; CLI flags `--dram-controller-model` / `--dram-controller-capacity-scale` wired (both default to current behavior).

## Caveats — please read before enabling `enforce`

1. **The per-controller capacity constant is unvalidated against silicon.** tt-npe says 40.0 B/cyc/controller on BH (54.0 / 1.35 GHz, `NUM_CHANNELS_PER_CONTROLLER=1` ⇒ 432 GB/s/chip); the datasheet figure of 512 GB/s implies 47.4 B/cyc — a ~19% disagreement with no comment explaining the 54.0. Independently, tt-metal's `test_bounds.yaml` measures 33–34 B/cyc single-core DRAM on BH, so the per-NIU rate is already ~18% optimistic before any controller effect. `enforce` inherits this in proportion. Hence default `off` and the `capacity_scale` knob. Calibrating properly needs silicon (sweep `8_dram_adjacent_core_read --num-banks 1..8`, take the slope).
2. **`enforce` is not monotone.** 2 of the 7 trace deltas are *negative* (−1.40%, −3.49%). Slowing a transfer changes 128-cycle timestep quantization and which transfers overlap, and `estimated_cycles` is a max over transfer end cycles. Pre-existing model behavior, but it means `enforce` is not a pure slowdown.
3. **High per-controller demand does not guarantee a cycle change.** A WH spread case reports 294.9% peak / 66% saturation yet `enforce == off`, because the critical path wasn't the DRAM-limited portion. Treat the demand signal as diagnostic.
4. **Reads and writes share one bucket per controller.** Whether GDDR6 on these parts provisions read/write paths independently is unverified; the shared bucket is the conservative choice. If they are independent, mixed R/W workloads are over-derated by up to 2×. Decisive experiment needs silicon.
5. **Reported demand is *offered* demand**, sampled from un-derated bandwidths at the top of each timestep (`NUM_ITERS == 1`) — exactly like the existing link/NIU grids. It therefore reads identically under `observe` and `enforce`; only `estimated_cycles` differs. Asserted in the tests and documented.
6. **noc-trace payload saturation biases the signal low:** `event_metadata.hpp` encodes payload as `min(255, ceil(bytes/32))*32` capped at 8160 B, while BH `NOC_MAX_BURST_SIZE` is 16384 B. Large-page interleaved DRAM reads are recorded at up to half their true size, so demand is understated. Do **not** compensate by inflating capacity.
7. **Timestep quantization under-detects short hotspots** (default `cycles_per_timestep=128`); `saturated_frac` is reported alongside peak to partially compensate. A sensitivity sweep hasn't been run.

Deliberately out of scope: the DRAM grid is **not** emitted into the timeline JSON and `CURRENT_TIMELINE_SCHEMA_VERSION` stays `1.0.0`, so existing timeline consumers and the visualizer see byte-identical output.

Also noticed but left alone (pre-existing on `main`, happy to file separately): `tt_npe.py` crashes after a successful sim on `result.wallclock_runtime_us` (no longer on `Stats`), and `overall_max_niu_demand` is a peak-of-*average* despite its name — fixing the latter would silently move published NIU numbers.

## Motivation

We generate data-movement kernels in tt-dm-codegen and are chasing sharded/strided writer losses (sharded pad 21–85× vs ttnn; width/block-sharded transpose/untilize 33–51×). We want to A/B contention-free rewrites offline on CPU instead of spending a device-exclusive sweep per iteration — and DRAM-bandwidth-bound ops need the controller term to show up at all.
