### PR TITLE
fix(cli): tt_npe.py crashes with AttributeError after every successful run

### DIFF
--- a/tt_npe/py/pycli/tt_npe.py
+++ b/tt_npe/py/pycli/tt_npe.py
@@ -158,7 +158,14 @@ def main():
     result = npe_api.runNPE(wl)
     match type(result):
         case npe.Stats:
-            print(f"tt-npe simulation finished successfully in {result.wallclock_runtime_us} us!");
+            # wallclock_runtime_us is a field of deviceStats, not of the top-level
+            # Stats object (which only carries per_device_stats), so reading it
+            # directly off `result` raises AttributeError *after* a successful sim.
+            runtime_us = max(
+                (ds.wallclock_runtime_us for ds in result.per_device_stats.values()),
+                default=0,
+            )
+            print(f"tt-npe simulation finished successfully in {runtime_us} us!");
             print("--- stats ----------------------------------")
             print(result)
         case npe.Exception:


### PR DESCRIPTION
## Problem

`tt_npe.py` raises `AttributeError` on **every successful run**. The simulation itself completes fine — only the final success print fails — so the user loses the entire stats report and gets a traceback instead.

`wallclock_runtime_us` is a field of `npeStats::deviceStats` (`npeStats.hpp:57`, bound at `bindings.cpp:50`). The top-level `npeStats` object carries only `per_device_stats`, so `result.wallclock_runtime_us` does not exist.

## Reproduce (on `main`, no silicon required)

```bash
./create_venv_uv.sh && ./build-npe.sh
export PYTHONPATH=install/lib:install/bin
/usr/bin/python3 install/bin/tt_npe.py -w tt_npe/workload/example_wl.json
```

**Observed:**
```
Loaded workload successfully, starting tt-npe ...
Traceback (most recent call last):
  File "install/bin/tt_npe.py", line 186, in main
    print(f"tt-npe simulation finished successfully in {result.wallclock_runtime_us} us!");
AttributeError: 'tt_npe_pybind.Stats' object has no attribute 'wallclock_runtime_us'
```

**Expected:** the sim already succeeded, so it should print the success line and the stats block.

## Fix

Take the max `wallclock_runtime_us` across `per_device_stats` (the simulation's wall time) and print that.

**After the change**, the same command completes and prints the full report:
```
    avg NIU  demand:   0.9%
    max NIU  demand:   1.4%

   wallclock time:   148 us
```

## Notes

- Behaviour-only change to the CLI; no model, stats, or binding code touched, so no simulation numbers move.
- Found while driving tt-npe from the Python API for offline NoC modelling of data-movement kernels — we had to bypass the CLI entirely because of this.
- Unrelated to (and independent of) #125.


---

**Merge order:** #126, #128, #129 and #130 are mutually independent — verified by building their union (62/62 gtest, 23/23 pytest, and bit-identical to `main` at default settings across all 71 bundled traces). They can land in any order.

#125 is the only one that conflicts (with #128 on the `deviceStats` pickle tuple, and with #130 on the congestion hook), so **please merge #125 last** — I'll rebase it once the others land.
