### PR TITLE
fix(stats): "max NIU/Link demand" is the max of a spatial average, not a per-NIU/per-link peak

### DIFF
--- a/tt_npe/cpp/include/npeStats.hpp
+++ b/tt_npe/cpp/include/npeStats.hpp
@@ -25,9 +25,11 @@ struct TimestepStats {
     double avg_link_demand = 0;
     // In contrast to link demand, link _util_ is the number of cycles in a
     // timestep a link(s) is used; this cannot exceed 100%.
+    // max_link_demand is the demand of the single busiest link in this timestep
     double max_link_demand = 0;
     double avg_link_util = 0;
     double avg_niu_demand = 0;
+    // max_niu_demand is the demand of the single busiest NIU in this timestep
     double max_niu_demand = 0;
 
     // noc0 stats
@@ -56,11 +58,24 @@ struct npeStats {
         double cycle_prediction_error = 0.0;
         size_t wallclock_runtime_us = 0;
         double overall_avg_link_demand = 0;
+        // NOTE: overall_max_*_demand is the max over timesteps of the *spatial
+        // average* demand across all links/NIUs. It answers "at the worst
+        // moment, what was the average link/NIU doing?", NOT "what was the
+        // busiest link/NIU doing?". Use overall_peak_*_demand below for the
+        // latter. These fields are kept as-is for backwards compatibility with
+        // existing consumers of these numbers.
         double overall_max_link_demand = 0;
         double overall_avg_link_util = 0;
         double overall_max_link_util = 0;
         double overall_avg_niu_demand = 0;
         double overall_max_niu_demand = 0;
+
+        // True per-link/per-NIU peak demand: max over both timesteps *and*
+        // links/NIUs. This is what identifies a single congested hotspot,
+        // which a spatial average washes out. Always >= the corresponding
+        // overall_max_*_demand field.
+        double overall_peak_link_demand = 0;
+        double overall_peak_niu_demand = 0;
 
         // noc0 stats
         double overall_avg_noc0_link_demand = 0;

--- a/tt_npe/cpp/pybind/bindings.cpp
+++ b/tt_npe/cpp/pybind/bindings.cpp
@@ -52,6 +52,10 @@ PYBIND11_MODULE(tt_npe_pybind, m) {
         .def_readwrite("overall_max_link_demand", &tt_npe::npeStats::deviceStats::overall_max_link_demand)
         .def_readwrite("overall_avg_niu_demand", &tt_npe::npeStats::deviceStats::overall_avg_niu_demand)
         .def_readwrite("overall_max_niu_demand", &tt_npe::npeStats::deviceStats::overall_max_niu_demand)
+        // true per-link/per-NIU peaks (max over both timesteps and links/NIUs);
+        // overall_max_*_demand above are maxima of the *spatial average* demand
+        .def_readwrite("overall_peak_link_demand", &tt_npe::npeStats::deviceStats::overall_peak_link_demand)
+        .def_readwrite("overall_peak_niu_demand", &tt_npe::npeStats::deviceStats::overall_peak_niu_demand)
         .def_readwrite("overall_avg_link_util", &tt_npe::npeStats::deviceStats::overall_avg_link_util)
         .def_readwrite("overall_max_link_util", &tt_npe::npeStats::deviceStats::overall_max_link_util)
         .def_readwrite("overall_avg_noc0_link_demand", &tt_npe::npeStats::deviceStats::overall_avg_noc0_link_demand)
@@ -123,10 +127,16 @@ PYBIND11_MODULE(tt_npe_pybind, m) {
                 ds.dram_bw_util,
                 ds.dram_bw_util_sim,
                 eth_bw_list,
-                dram_bw_dict);
+                dram_bw_dict,
+                // NOTE: new fields are appended at the end so that the tuple
+                // indices of all pre-existing fields stay stable
+                ds.overall_peak_link_demand,
+                ds.overall_peak_niu_demand);
         },
         [](py::tuple t) {
-            if (t.size() != 23) {
+            // 23 == the pre-overall_peak_*_demand tuple layout; still accepted so
+            // that pickles written by older builds keep loading
+            if (t.size() != 23 && t.size() != 25) {
                 throw std::runtime_error("Invalid deviceStats pickle state!");
             }
             tt_npe::npeStats::deviceStats ds;
@@ -164,6 +174,10 @@ PYBIND11_MODULE(tt_npe_pybind, m) {
             py::dict dram_bw_dict = t[22].cast<py::dict>();
             for (const auto& item : dram_bw_dict) {
                 ds.dram_bw_util_per_controller[item.first.cast<uint32_t>()] = item.second.cast<double>();
+            }
+            if (t.size() > 23) {
+                ds.overall_peak_link_demand = t[23].cast<double>();
+                ds.overall_peak_niu_demand = t[24].cast<double>();
             }
             return ds;
         }));

--- a/tt_npe/cpp/src/npeStats.cpp
+++ b/tt_npe/cpp/src/npeStats.cpp
@@ -105,11 +105,15 @@ std::string npeStats::deviceStats::to_string(bool verbose) const {
             overall_avg_mcast_write_link_util));
     output.append(fmt::format("      max Link util: {:5.1f}%\n", overall_max_link_util));
     output.append("\n");
+    // NB: "max avg" is the max over timesteps of the spatial average demand;
+    // "peak" is the demand of the single busiest link/NIU in any timestep.
     output.append(fmt::format("    avg Link demand: {:5.1f}%\n", overall_avg_link_demand));
-    output.append(fmt::format("    max Link demand: {:5.1f}%\n", overall_max_link_demand));
+    output.append(fmt::format("max avg Link demand: {:5.1f}%\n", overall_max_link_demand));
+    output.append(fmt::format("   peak Link demand: {:5.1f}%\n", overall_peak_link_demand));
     output.append("\n");
     output.append(fmt::format("    avg NIU  demand: {:5.1f}%\n", overall_avg_niu_demand));
-    output.append(fmt::format("    max NIU  demand: {:5.1f}%\n", overall_max_niu_demand));
+    output.append(fmt::format("max avg NIU  demand: {:5.1f}%\n", overall_max_niu_demand));
+    output.append(fmt::format("   peak NIU  demand: {:5.1f}%\n", overall_peak_niu_demand));
 
     if (verbose) {
         output.append("\n");
@@ -122,10 +126,16 @@ std::string npeStats::deviceStats::to_string(bool verbose) const {
 void npeStats::deviceStats::computeSummaryStats(const npeWorkload& wl, const npeDeviceModel& device_model, DeviceID device_id) {
     for (const auto &ts : per_timestep_stats) {
         overall_avg_niu_demand += ts.avg_niu_demand;
+        // NB: overall_max_niu_demand is the max over timesteps of the *spatial
+        // average* NIU demand, not the demand of the busiest NIU; kept for
+        // backwards compatibility. overall_peak_niu_demand is the true per-NIU peak.
         overall_max_niu_demand = std::max(overall_max_niu_demand, ts.avg_niu_demand);
+        overall_peak_niu_demand = std::max(overall_peak_niu_demand, ts.max_niu_demand);
 
         overall_avg_link_demand += ts.avg_link_demand;
+        // NB: same caveat as overall_max_niu_demand above
         overall_max_link_demand = std::max(overall_max_link_demand, ts.avg_link_demand);
+        overall_peak_link_demand = std::max(overall_peak_link_demand, ts.max_link_demand);
 
         overall_avg_link_util += ts.avg_link_util;
         overall_max_link_util = std::max(overall_max_link_util, ts.avg_link_util);

--- a/tt_npe/cpp/test/test_npe_stats.cpp
+++ b/tt_npe/cpp/test/test_npe_stats.cpp
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Tenstorrent AI ULC
+
+#include <filesystem>
+
+#include "gtest/gtest.h"
+#include "ingestWorkload.hpp"
+#include "npeAPI.hpp"
+#include "npeCommon.hpp"
+#include "npeConfig.hpp"
+#include "npeStats.hpp"
+
+namespace tt_npe {
+namespace {
+
+npeConfig makeConfig() {
+    npeConfig cfg;
+    cfg.device_name = "wormhole_b0";
+    cfg.congestion_model_name = "fast";
+    cfg.cycles_per_timestep = 128;
+    cfg.setVerbosityLevel(0);
+    return cfg;
+}
+
+// Builds a workload where `num_senders` worker cores all write to the *same*
+// destination core. The sink NIU of that destination is oversubscribed by
+// roughly num_senders x, while every other NIU on the device is idle.
+npeWorkload makeHotNIUWorkload(size_t num_senders) {
+    npeWorkload wl;
+    npeWorkloadPhase phase;
+    const DeviceID device_id = 0;
+    const Coord hot_dst{device_id, 9, 9};
+    for (size_t i = 0; i < num_senders; i++) {
+        // rows 1..N, col 1 are WORKER cores on wormhole_b0
+        Coord src{device_id, int(1 + i), 1};
+        phase.transfers.push_back(
+            npeWorkloadTransfer(8192, 32, src, hot_dst, 28.1, 0, nocType::NOC0));
+    }
+    wl.addPhase(phase);
+    wl.setGoldenResultCycles({{device_id, {0, 32}}});
+    return wl;
+}
+
+const npeStats::deviceStats &meshStats(const npeResult &result) {
+    return std::get<npeStats>(result).per_device_stats.at(MESH_DEVICE);
+}
+
+}  // namespace
+
+// The true per-NIU/per-link peak can never be below the max of the spatial
+// average, since a max over a set is always >= the mean of that set.
+TEST(npeStatsTest, PeakDemandIsAtLeastMaxAvgDemand) {
+    npeAPI api(makeConfig());
+    auto result = api.runNPE(makeHotNIUWorkload(8));
+    ASSERT_TRUE(std::holds_alternative<npeStats>(result));
+    const auto &stats = meshStats(result);
+
+    EXPECT_GE(stats.overall_peak_niu_demand, stats.overall_max_niu_demand);
+    EXPECT_GE(stats.overall_peak_link_demand, stats.overall_max_link_demand);
+    EXPECT_GT(stats.overall_peak_niu_demand, 0.0);
+    EXPECT_GT(stats.overall_peak_link_demand, 0.0);
+}
+
+// A single hot NIU among hundreds of idle ones is completely washed out by the
+// spatial average that overall_max_niu_demand is built from; overall_peak_niu_demand
+// must report the hot NIU instead.
+TEST(npeStatsTest, PeakNiuDemandExposesHotspotDilutedByAverage) {
+    constexpr size_t kNumSenders = 8;
+    npeAPI api(makeConfig());
+    auto result = api.runNPE(makeHotNIUWorkload(kNumSenders));
+    ASSERT_TRUE(std::holds_alternative<npeStats>(result));
+    const auto &stats = meshStats(result);
+
+    // the shared sink NIU carries ~kNumSenders concurrent transfers, so it is
+    // oversubscribed well beyond 100% of a single NIU's bandwidth
+    EXPECT_GT(stats.overall_peak_niu_demand, 100.0);
+
+    // ...while the spatial average over all NIUs on the device stays tiny
+    EXPECT_LT(stats.overall_max_niu_demand, 20.0);
+
+    // the hotspot is at least an order of magnitude larger than the diluted stat
+    EXPECT_GT(stats.overall_peak_niu_demand, 10.0 * stats.overall_max_niu_demand);
+}
+
+// Scaling the number of senders into a single destination scales the peak NIU
+// demand, but barely moves the spatially-averaged stat.
+TEST(npeStatsTest, PeakNiuDemandTracksHotspotIntensity) {
+    npeAPI api(makeConfig());
+
+    auto light = api.runNPE(makeHotNIUWorkload(2));
+    auto heavy = api.runNPE(makeHotNIUWorkload(8));
+    ASSERT_TRUE(std::holds_alternative<npeStats>(light));
+    ASSERT_TRUE(std::holds_alternative<npeStats>(heavy));
+
+    EXPECT_GT(meshStats(heavy).overall_peak_niu_demand,
+              2.0 * meshStats(light).overall_peak_niu_demand);
+}
+
+// Regression guard on a bundled tt-metal noc trace. Skipped when the test is
+// invoked from a working directory where the bundled workloads aren't visible.
+TEST(npeStatsTest, PeakNiuDemandOnBundledNocTrace) {
+    const std::string trace_path = "workload/noc_trace_json/2x2_BLOCK_TO_8x8_BLOCK.json";
+    if (!std::filesystem::exists(trace_path)) {
+        GTEST_SKIP() << "bundled noc trace not reachable from cwd; run from tt_npe/";
+    }
+    auto workload = createWorkloadFromJSON(trace_path, "wormhole_b0", true);
+    ASSERT_TRUE(workload.has_value());
+
+    npeAPI api(makeConfig());
+    auto result = api.runNPE(*workload);
+    ASSERT_TRUE(std::holds_alternative<npeStats>(result));
+    const auto &stats = meshStats(result);
+
+    // On this trace the busiest NIU is oversubscribed ~5.6x (562% of the 30
+    // B/cycle link bandwidth tt-npe normalizes demand against) while the max of
+    // the spatial average sits at 5.5%.
+    EXPECT_GE(stats.overall_peak_niu_demand, stats.overall_max_niu_demand);
+    EXPECT_GT(stats.overall_peak_niu_demand, 100.0);
+    EXPECT_LT(stats.overall_max_niu_demand, 100.0);
+}
+
+}  // namespace tt_npe

--- a/tt_npe/py/pytest/test_bindings.py
+++ b/tt_npe/py/pytest/test_bindings.py
@@ -110,3 +110,84 @@ def test_npe_create_and_run_larger_synthetic_workload():
     assert npe_api is not None
     result = npe_api.runNPE(wl)
     assert type(result) == npe.Stats
+
+
+def _run_hot_niu_workload(num_senders):
+    """All senders write into the same destination core, so a single sink NIU is
+    oversubscribed while every other NIU on the device stays idle."""
+    phase = npe.Phase()
+    hot_dst = npe.Coord(0, 9, 9)
+    for i in range(num_senders):
+        # rows 1..N, col 1 are WORKER cores on wormhole_b0
+        phase.addTransfer(
+            npe.Transfer(8192, 32, npe.Coord(0, 1 + i, 1), hot_dst, 28.1, 0, npe.NocType.NOC_0)
+        )
+
+    wl = npe.Workload()
+    wl.addPhase(phase)
+    wl.setGoldenResultCycles({0: (0, 32)})
+
+    cfg = npe.Config()
+    cfg.device_name = "wormhole_b0"
+    cfg.congestion_model_name = "fast"
+    npe_api = npe.InitAPI(cfg)
+    assert npe_api is not None
+    result = npe_api.runNPE(wl)
+    assert type(result) == npe.Stats
+    return result.per_device_stats[-1]
+
+
+def test_npe_peak_demand_stats_are_exposed():
+    ds = _run_hot_niu_workload(8)
+    assert ds.overall_peak_niu_demand > 0.0
+    assert ds.overall_peak_link_demand > 0.0
+    # a max over a set is always >= the max of that set's spatial average
+    assert ds.overall_peak_niu_demand >= ds.overall_max_niu_demand
+    assert ds.overall_peak_link_demand >= ds.overall_max_link_demand
+
+
+def test_npe_peak_niu_demand_exposes_hotspot_diluted_by_average():
+    ds = _run_hot_niu_workload(8)
+    # the shared sink NIU is oversubscribed well past 100% of one NIU's bandwidth
+    assert ds.overall_peak_niu_demand > 100.0
+    # ...while the spatial average across all NIUs on the device stays tiny
+    assert ds.overall_max_niu_demand < 20.0
+    assert ds.overall_peak_niu_demand > 10.0 * ds.overall_max_niu_demand
+
+
+def test_npe_peak_demand_stats_survive_pickle_roundtrip():
+    import pickle
+
+    ds = _run_hot_niu_workload(8)
+    restored = pickle.loads(pickle.dumps(ds))
+    assert restored.overall_peak_niu_demand == ds.overall_peak_niu_demand
+    assert restored.overall_peak_link_demand == ds.overall_peak_link_demand
+    # pre-existing fields must round-trip unchanged as well
+    assert restored.overall_max_niu_demand == ds.overall_max_niu_demand
+    assert restored.overall_max_link_demand == ds.overall_max_link_demand
+    assert restored.estimated_cycles == ds.estimated_cycles
+
+
+def test_npe_legacy_pickle_state_still_loads():
+    """A pickle written before overall_peak_*_demand existed had 23 tuple elements;
+    it must still load, with the new fields defaulting to 0."""
+    ds = _run_hot_niu_workload(8)
+    state = ds.__getstate__()
+    assert len(state) == 25
+
+    legacy = npe.DeviceStats.__new__(npe.DeviceStats)
+    legacy.__setstate__(tuple(state[:23]))
+    assert legacy.overall_max_niu_demand == ds.overall_max_niu_demand
+    assert legacy.estimated_cycles == ds.estimated_cycles
+    assert legacy.overall_peak_niu_demand == 0.0
+    assert legacy.overall_peak_link_demand == 0.0
+
+
+def test_npe_peak_demand_stats_appear_in_report():
+    ds = _run_hot_niu_workload(8)
+    report = str(ds)
+    assert "peak NIU  demand" in report
+    assert "peak Link demand" in report
+    # existing rows are relabeled to make clear they are maxima of an average
+    assert "max avg NIU  demand" in report
+    assert "max avg Link demand" in report


### PR DESCRIPTION

---

**Merge order:** #126, #128, #129 and #130 are mutually independent — verified by building their union (62/62 gtest, 23/23 pytest, and bit-identical to `main` at default settings across all 71 bundled traces). They can land in any order.

#125 is the only one that conflicts (with #128 on the `deviceStats` pickle tuple, and with #130 on the congestion hook), so **please merge #125 last** — I'll rebase it once the others land.
