### PR TITLE
fix(ci): stray quote makes community-issue-tagging.yml invalid YAML (fails on every push)

### DIFF
--- a/.github/workflows/community-issue-tagging.yml
+++ b/.github/workflows/community-issue-tagging.yml
@@ -1,4 +1,4 @@
-name: "Community Issue / PR Labeling Workflow""
+name: "Community Issue / PR Labeling Workflow"
 
 on:
   issues:


### PR DESCRIPTION
## Problem

`.github/workflows/community-issue-tagging.yml` fails on **every push, on every branch**, completing in 0s. It shows up as a red ❌ on every PR and push, so the signal is permanently noisy — and the labeling action it's supposed to run never executes.

Line 1 has a stray trailing double-quote:

```yaml
name: "Community Issue / PR Labeling Workflow""
```

That makes the whole file invalid YAML, so GitHub can't even schedule the job.

## Reproduce

```bash
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/community-issue-tagging.yml'))"
```

**Observed:**
```
yaml.scanner.ScannerError: while scanning a quoted scalar
  in ".github/workflows/community-issue-tagging.yml", line 1, column 47
found unexpected end of stream
  in ".github/workflows/community-issue-tagging.yml", line 13, column 1
```

Or in the Actions tab — every push run of this workflow is `failure` with 0s duration, e.g. on three separate branches: runs 30687996597, 30687531973, 30674004435.

**Expected:** the file parses and the labeling workflow runs (or is correctly skipped) instead of hard-failing.

## Fix

Delete the extra `"`. One character.

**After:** the YAML parses cleanly.

## Notes

- Pre-existing on `main` (introduced in 3ce4534). Not related to my other PRs, though it is what makes them show a spurious red check.
- Filed alongside #125 (per-DRAM-controller congestion), #126 (CLI crash), and #127 (first-order congestion issue).


---

**Merge order:** #126, #128, #129 and #130 are mutually independent — verified by building their union (62/62 gtest, 23/23 pytest, and bit-identical to `main` at default settings across all 71 bundled traces). They can land in any order.

#125 is the only one that conflicts (with #128 on the `deviceStats` pickle tuple, and with #130 on the congestion hook), so **please merge #125 last** — I'll rebase it once the others land.
