### PR TITLE
Fix single-packet bandwidth degeneration in interpolateBW (opt-in latency_floor mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,24 @@ Bandwidth derating caused by congestion between concurrent transfers is
 modelled **by default**. Congestion modelling can be *disabled* using
 `--cong-model none`.
 
+`--single-packet-bw-model` selects how the bandwidth of a *single packet*
+(`num_packets == 1`) transfer is derived from the device's transfer bandwidth
+table:
+
+| mode | behavior |
+|---|---|
+| `legacy` **(default)** | A single packet is modelled at the device's peak bandwidth regardless of its size. Preserves historical predictions exactly. |
+| `latency_floor` | A single packet is modelled at the size-appropriate steady-state bandwidth from the transfer bandwidth table. |
+
+Under `legacy` the blend in `interpolateBW()` degenerates at `num_packets == 1`
+(the "first transfer" term gets weight 1.0), so a 16 B transaction and an 8 KB
+transaction are modelled at the same bandwidth. `latency_floor` instead charges
+the table rate, which below the table's knee is a roughly fixed number of cycles
+per transaction (~21 cycles on Blackhole, ~23 cycles for packets up to 128 B on
+Wormhole). **`latency_floor` changes predictions and is not silicon-validated;**
+it is opt-in for that reason. It is also available as
+`npeConfig.single_packet_bandwidth_model` in the C++ and Python APIs.
+
 The `-e` option dumps detailed information about simulation timeline (e.g.
 congestion and transfer state for each timestep) into a JSON file located at
 `npe_timeline.json` (by default). Future work is to load this data into a

--- a/tt_npe/cpp/include/device_models/blackhole.hpp
+++ b/tt_npe/cpp/include/device_models/blackhole.hpp
@@ -212,13 +212,15 @@ class BlackholeDeviceModel : public npeDeviceModel {
         std::vector<PETransferState> &transfer_state,
         const std::vector<PETransferID> &live_transfer_ids,
         npeDeviceState &device_state,
-        bool enable_congestion_model) const override {
+        bool enable_congestion_model,
+        SinglePacketBWModel single_packet_bw_model = SinglePacketBWModel::Legacy) const override {
         // Compute bandwidth for this timestep for all live transfers
         updateTransferBandwidth(
             &transfer_state,
             live_transfer_ids,
             getTransferBandwidthTable(),
-            getMaxNoCTransferBandwidth());
+            getMaxNoCTransferBandwidth(),
+            single_packet_bw_model);
 
         // model congestion and derate bandwidth
         if (enable_congestion_model) {

--- a/tt_npe/cpp/include/device_models/blackhole_multichip.hpp
+++ b/tt_npe/cpp/include/device_models/blackhole_multichip.hpp
@@ -209,14 +209,16 @@ class BlackholeMultichipDeviceModel : public npeDeviceModel {
          std::vector<PETransferState> &transfer_state,
          const std::vector<PETransferID> &live_transfer_ids,
          npeDeviceState &device_state,
-         bool enable_congestion_model) const override {
+         bool enable_congestion_model,
+         SinglePacketBWModel single_packet_bw_model = SinglePacketBWModel::Legacy) const override {
  
          // Compute bandwidth for this timestep for all live transfers
          updateTransferBandwidth(
              &transfer_state,
              live_transfer_ids,
              _blackhole_model.getTransferBandwidthTable(),
-             _blackhole_model.getMaxNoCTransferBandwidth());
+             _blackhole_model.getMaxNoCTransferBandwidth(),
+             single_packet_bw_model);
  
          // model congestion and derate bandwidth
          if (enable_congestion_model) {

--- a/tt_npe/cpp/include/device_models/wormhole_b0.hpp
+++ b/tt_npe/cpp/include/device_models/wormhole_b0.hpp
@@ -200,13 +200,15 @@ class WormholeB0DeviceModel : public npeDeviceModel {
         std::vector<PETransferState> &transfer_state,
         const std::vector<PETransferID> &live_transfer_ids,
         npeDeviceState &device_state,
-        bool enable_congestion_model) const override {
+        bool enable_congestion_model,
+        SinglePacketBWModel single_packet_bw_model = SinglePacketBWModel::Legacy) const override {
         // Compute bandwidth for this timestep for all live transfers
         updateTransferBandwidth(
             &transfer_state,
             live_transfer_ids,
             getTransferBandwidthTable(),
-            getMaxNoCTransferBandwidth());
+            getMaxNoCTransferBandwidth(),
+            single_packet_bw_model);
 
         // model congestion and derate bandwidth
         if (enable_congestion_model) {

--- a/tt_npe/cpp/include/device_models/wormhole_multichip.hpp
+++ b/tt_npe/cpp/include/device_models/wormhole_multichip.hpp
@@ -222,14 +222,16 @@ class WormholeMultichipDeviceModel : public npeDeviceModel {
         std::vector<PETransferState> &transfer_state,
         const std::vector<PETransferID> &live_transfer_ids,
         npeDeviceState &device_state,
-        bool enable_congestion_model) const override {
+        bool enable_congestion_model,
+        SinglePacketBWModel single_packet_bw_model = SinglePacketBWModel::Legacy) const override {
 
         // Compute bandwidth for this timestep for all live transfers
         updateTransferBandwidth(
             &transfer_state,
             live_transfer_ids,
             _wormhole_b0_model.getTransferBandwidthTable(),
-            _wormhole_b0_model.getMaxNoCTransferBandwidth());
+            _wormhole_b0_model.getMaxNoCTransferBandwidth(),
+            single_packet_bw_model);
 
         // model congestion and derate bandwidth
         if (enable_congestion_model) {

--- a/tt_npe/cpp/include/npeCommon.hpp
+++ b/tt_npe/cpp/include/npeCommon.hpp
@@ -18,6 +18,17 @@ using DeviceID = int16_t;
 
 enum class nocType { NOC0 = 0, NOC1 = 1 };
 
+// Selects how the bandwidth of a *single packet* (num_packets == 1) transfer is derived from the
+// device's transfer bandwidth table. See interpolateBW() in npeDeviceModelUtils.hpp.
+enum class SinglePacketBWModel : unsigned char {
+    // Legacy behavior: the "first transfer" term of the blend gets weight 1.0, so a single packet
+    // is always modelled at the table's peak bandwidth regardless of its size.
+    Legacy = 0,
+    // A single packet is modelled at the size-appropriate steady-state bandwidth from the table,
+    // which below the table's knee is equivalent to a fixed per-transaction latency floor.
+    LatencyFloor = 1,
+};
+
 enum class npeErrorCode {
     UNDEF = 0,
     WORKLOAD_VALIDATION_FAILED = 1,

--- a/tt_npe/cpp/include/npeConfig.hpp
+++ b/tt_npe/cpp/include/npeConfig.hpp
@@ -17,6 +17,11 @@ enum class VerbosityLevel { Normal = 0, Verbose = 1, MoreVerbose = 2, MostVerbos
 struct npeConfig {
     std::string device_name = "wormhole_b0";
     std::string congestion_model_name = "fast";
+    // "legacy"        : single-packet transfers are modelled at peak bandwidth (default; preserves
+    //                   historical predictions exactly)
+    // "latency_floor" : single-packet transfers are modelled at the size-appropriate steady-state
+    //                   bandwidth from the transfer bandwidth table
+    std::string single_packet_bandwidth_model = "legacy";
     std::string workload_json;
     Cycle cycles_per_timestep = 128;
     VerbosityLevel verbosity = VerbosityLevel::Normal;
@@ -33,6 +38,10 @@ struct npeConfig {
     std::string topology_json; // Path to topology JSON file
     Timestep timeline_split_threshold_timesteps = 10000; // Threshold for splitting timeline files
 
+    SinglePacketBWModel getSinglePacketBWModel() const {
+        return single_packet_bandwidth_model == "latency_floor" ? SinglePacketBWModel::LatencyFloor
+                                                                : SinglePacketBWModel::Legacy;
+    }
     void setVerbosityLevel(int vlvl) {
         vlvl = std::clamp(vlvl, 0, 3);
         verbosity = VerbosityLevel(vlvl);
@@ -50,6 +59,8 @@ struct npeConfig {
         repr += fmt::format("\n  timeline_filepath                  = \"{}\"", timeline_filepath);
         repr += "\n";
         repr += fmt::format("\n  congestion_model_name              = {}", congestion_model_name);
+        repr += fmt::format(
+            "\n  single_packet_bandwidth_model      = {}", single_packet_bandwidth_model);
         repr += fmt::format("\n  estimate_cong_impact               = {}", estimate_cong_impact);
         repr += fmt::format("\n  cycles_per_timestep                = {}", cycles_per_timestep);
         repr += fmt::format(

--- a/tt_npe/cpp/include/npeDeviceModelIface.hpp
+++ b/tt_npe/cpp/include/npeDeviceModelIface.hpp
@@ -38,7 +38,8 @@ class npeDeviceModel {
         std::vector<PETransferState> &transfer_state,
         const std::vector<PETransferID> &live_transfer_ids,
         npeDeviceState &device_state,
-        bool enable_congestion_model) const = 0;
+        bool enable_congestion_model,
+        SinglePacketBWModel single_packet_bw_model = SinglePacketBWModel::Legacy) const = 0;
 
     virtual DeviceArch getArch() const = 0;
 

--- a/tt_npe/cpp/include/npeDeviceModelUtils.hpp
+++ b/tt_npe/cpp/include/npeDeviceModelUtils.hpp
@@ -17,7 +17,8 @@ inline float interpolateBW(
     const TransferBandwidthTable &tbt,
     float max_transfer_bw,
     size_t packet_size,
-    size_t num_packets) {
+    size_t num_packets,
+    SinglePacketBWModel single_packet_bw_model = SinglePacketBWModel::Legacy) {
     TT_ASSERT(packet_size > 0);
     for (int fst = 0; fst < tbt.size() - 1; fst++) {
         size_t start_range = tbt[fst].first;
@@ -27,6 +28,14 @@ inline float interpolateBW(
             float pct = (packet_size - start_range) / delta;
             float val_delta = tbt[fst + 1].second - tbt[fst].second;
             float steady_state_bw = (val_delta * pct) + tbt[fst].second;
+
+            // A lone packet has no steady state to blend with; the whole transfer *is* the first
+            // (and only) transaction, and its cost is the per-transaction cost the table already
+            // encodes. Applying the blend below with num_packets == 1 gives the first-transfer term
+            // weight 1.0, which returns peak bandwidth for any packet size.
+            if (single_packet_bw_model == SinglePacketBWModel::LatencyFloor && num_packets <= 1) {
+                return steady_state_bw;
+            }
 
             float first_transfer_bw = max_transfer_bw;
             float steady_state_ratio = float(num_packets - 1) / num_packets;
@@ -52,14 +61,16 @@ inline void updateTransferBandwidth(
     std::vector<PETransferState> *transfers,
     const std::vector<PETransferID> &live_transfer_ids,
     const TransferBandwidthTable &transfer_bandwidth_table,
-    float max_transfer_bandwidth) {
+    float max_transfer_bandwidth,
+    SinglePacketBWModel single_packet_bw_model = SinglePacketBWModel::Legacy) {
     for (auto &ltid : live_transfer_ids) {
         auto &lt = (*transfers)[ltid];
         auto noc_limited_bw = interpolateBW(
             transfer_bandwidth_table,
             max_transfer_bandwidth,
             lt.params.packet_size,
-            lt.params.num_packets);
+            lt.params.num_packets,
+            single_packet_bw_model);
         lt.curr_bandwidth = std::fmin(lt.params.injection_rate, noc_limited_bw);
     }
 }

--- a/tt_npe/cpp/pybind/bindings.cpp
+++ b/tt_npe/cpp/pybind/bindings.cpp
@@ -216,6 +216,8 @@ PYBIND11_MODULE(tt_npe_pybind, m) {
         .def(py::init<>())
         .def_readwrite("device_name", &tt_npe::npeConfig::device_name)
         .def_readwrite("congestion_model_name", &tt_npe::npeConfig::congestion_model_name)
+        .def_readwrite(
+            "single_packet_bandwidth_model", &tt_npe::npeConfig::single_packet_bandwidth_model)
         .def_readwrite("workload_json_filepath", &tt_npe::npeConfig::workload_json)
         .def_readwrite("cycles_per_timestep", &tt_npe::npeConfig::cycles_per_timestep)
         .def_readwrite("emit_timeline_file", &tt_npe::npeConfig::emit_timeline_file)

--- a/tt_npe/cpp/src/npeAPI.cpp
+++ b/tt_npe/cpp/src/npeAPI.cpp
@@ -24,6 +24,15 @@ void npeAPI::validateConfig() const {
             fmt::format(
                 "Illegal congestion model name '{}' in npeConfig", cfg.congestion_model_name));
     }
+    if (cfg.single_packet_bandwidth_model != "legacy" &&
+        cfg.single_packet_bandwidth_model != "latency_floor") {
+        throw npeException(
+            npeErrorCode::INVALID_CONFIG,
+            fmt::format(
+                "Illegal single packet bandwidth model '{}' in npeConfig; expected 'legacy' or "
+                "'latency_floor'",
+                cfg.single_packet_bandwidth_model));
+    }
 }
 
 npeWorkload npeAPI::preprocessWorkload(npeWorkload wl) const {

--- a/tt_npe/cpp/src/npeEngine.cpp
+++ b/tt_npe/cpp/src/npeEngine.cpp
@@ -205,6 +205,7 @@ npeResult npeEngine::runSinglePerfSim(const npeWorkload &wl, const npeConfig &cf
 
     // setup congestion tracking data structures
     bool enable_congestion_model = cfg.congestion_model_name != "none";
+    SinglePacketBWModel single_packet_bw_model = cfg.getSinglePacketBWModel();
     // Initialize device state with appropriate dimensions for this device model
     auto device_state = model->initDeviceState();
 
@@ -261,7 +262,8 @@ npeResult npeEngine::runSinglePerfSim(const npeWorkload &wl, const npeConfig &cf
             transfer_state,
             live_transfer_ids,
             *device_state,
-            enable_congestion_model);
+            enable_congestion_model,
+            single_packet_bw_model);
         
         // update stats
         updateSimulationStats(

--- a/tt_npe/cpp/test/test_npe_single_packet_bw.cpp
+++ b/tt_npe/cpp/test/test_npe_single_packet_bw.cpp
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Tenstorrent AI ULC
+
+#include "gtest/gtest.h"
+#include "device_models/blackhole.hpp"
+#include "device_models/wormhole_b0.hpp"
+#include "npeAPI.hpp"
+#include "npeCommon.hpp"
+#include "npeConfig.hpp"
+#include "npeDeviceModelUtils.hpp"
+
+namespace tt_npe {
+namespace {
+
+// Blackhole transfer bandwidth table (device_models/blackhole.hpp). Duplicated here so the tests
+// document the exact table they reason about; asserted to match the model below.
+const TransferBandwidthTable kBlackholeTBT = {
+    {0, 0},
+    {128, 6.0},
+    {256, 12.1},
+    {512, 24.2},
+    {1024, 48.0},
+    {2048, 57.7},
+    {4096, 58.7},
+    {8192, 60.4},
+    {16384, 60.9}};
+
+constexpr float kBlackholeMaxBW = 60.9f;
+
+float legacyBW(size_t packet_size, size_t num_packets) {
+    return interpolateBW(
+        kBlackholeTBT, kBlackholeMaxBW, packet_size, num_packets, SinglePacketBWModel::Legacy);
+}
+
+float latencyFloorBW(size_t packet_size, size_t num_packets) {
+    return interpolateBW(
+        kBlackholeTBT,
+        kBlackholeMaxBW,
+        packet_size,
+        num_packets,
+        SinglePacketBWModel::LatencyFloor);
+}
+
+}  // namespace
+
+// The table this test file reasons about must be the table the device model actually uses.
+TEST(npeSinglePacketBWTest, TestTableMatchesBlackholeModel) {
+    BlackholeDeviceModel model(BlackholeDeviceModel::DRAMHarvestingConfig::NO_HARVESTING);
+    const auto &tbt = model.getTransferBandwidthTable();
+    ASSERT_EQ(tbt.size(), kBlackholeTBT.size());
+    for (size_t i = 0; i < tbt.size(); i++) {
+        EXPECT_EQ(tbt[i].first, kBlackholeTBT[i].first);
+        EXPECT_FLOAT_EQ(tbt[i].second, kBlackholeTBT[i].second);
+    }
+    EXPECT_FLOAT_EQ(model.getMaxNoCTransferBandwidth(), kBlackholeMaxBW);
+}
+
+// Default argument must preserve historical behavior for every caller that does not opt in.
+TEST(npeSinglePacketBWTest, DefaultArgumentIsLegacy) {
+    for (size_t packet_size : {16, 128, 512, 1024, 2048, 4096, 8192}) {
+        for (size_t num_packets : {1, 2, 4, 17}) {
+            EXPECT_FLOAT_EQ(
+                interpolateBW(kBlackholeTBT, kBlackholeMaxBW, packet_size, num_packets),
+                legacyBW(packet_size, num_packets))
+                << "packet_size=" << packet_size << " num_packets=" << num_packets;
+        }
+    }
+}
+
+// The defect: with num_packets == 1 legacy returns peak bandwidth for *any* packet size.
+TEST(npeSinglePacketBWTest, LegacySinglePacketIsSizeIndependent) {
+    for (size_t packet_size : {16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192}) {
+        EXPECT_FLOAT_EQ(legacyBW(packet_size, 1), kBlackholeMaxBW)
+            << "packet_size=" << packet_size;
+    }
+}
+
+// latency_floor: a single packet is charged the size-appropriate table rate instead.
+TEST(npeSinglePacketBWTest, LatencyFloorSinglePacketIsSizeDependent) {
+    EXPECT_FLOAT_EQ(latencyFloorBW(128, 1), 6.0f);
+    EXPECT_FLOAT_EQ(latencyFloorBW(512, 1), 24.2f);
+    EXPECT_FLOAT_EQ(latencyFloorBW(1024, 1), 48.0f);
+    EXPECT_FLOAT_EQ(latencyFloorBW(2048, 1), 57.7f);
+
+    // strictly increasing with packet size below the knee
+    float prev = 0.0f;
+    for (size_t packet_size : {16, 32, 64, 128, 256, 512, 1024}) {
+        float bw = latencyFloorBW(packet_size, 1);
+        EXPECT_GT(bw, prev) << "packet_size=" << packet_size;
+        prev = bw;
+    }
+}
+
+// Below the knee the table is linear through the origin, so packet_size / bw -- the modelled cost
+// of one transaction in cycles -- is a constant. That constant is the latency floor.
+TEST(npeSinglePacketBWTest, LatencyFloorIsAConstantCyclesPerTransactionBelowKnee) {
+    const float expected_cycles = 128.0f / 6.0f;  // ~21.33
+    for (size_t packet_size : {16, 32, 64, 128, 256, 512, 1024}) {
+        float cycles = float(packet_size) / latencyFloorBW(packet_size, 1);
+        EXPECT_NEAR(cycles, expected_cycles, 0.35f) << "packet_size=" << packet_size;
+    }
+    // legacy charges ~0.26 cycles for a 16B transaction instead of ~21.3
+    EXPECT_NEAR(16.0f / legacyBW(16, 1), 0.263f, 0.001f);
+}
+
+// A 16B and a 512B single packet must no longer be modelled at the same bandwidth.
+TEST(npeSinglePacketBWTest, SubKneeRatioIsRestored) {
+    EXPECT_FLOAT_EQ(legacyBW(16, 1), legacyBW(512, 1));
+
+    float bw16 = latencyFloorBW(16, 1);
+    float bw512 = latencyFloorBW(512, 1);
+    EXPECT_LT(bw16, bw512);
+    // 32x fewer transactions for the same payload => ~32x less modelled time
+    EXPECT_NEAR(bw512 / bw16, 32.0f, 0.5f);
+}
+
+// Multi-packet behavior must be untouched in both modes.
+TEST(npeSinglePacketBWTest, MultiPacketBehaviorIsUnchanged) {
+    for (size_t packet_size : {16, 128, 512, 1024, 2048, 4096, 8192, 16384}) {
+        for (size_t num_packets : {2, 3, 8, 64, 1000}) {
+            EXPECT_FLOAT_EQ(
+                latencyFloorBW(packet_size, num_packets), legacyBW(packet_size, num_packets))
+                << "packet_size=" << packet_size << " num_packets=" << num_packets;
+        }
+    }
+}
+
+// Packet sizes at or above the largest table entry are unaffected in both modes (the early-return
+// path below the interpolation loop).
+TEST(npeSinglePacketBWTest, AboveTableIsUnchanged) {
+    for (size_t packet_size : {16384, 32768, 1 << 20}) {
+        EXPECT_FLOAT_EQ(latencyFloorBW(packet_size, 1), legacyBW(packet_size, 1))
+            << "packet_size=" << packet_size;
+    }
+}
+
+// The Wormhole table is flat from 2048B upward and its max equals that flat value, so the two modes
+// agree exactly over the whole packet-size range the bundled trace corpus uses (2048B / 4096B).
+TEST(npeSinglePacketBWTest, WormholeCorpusPacketSizesAreUnaffected) {
+    WormholeB0DeviceModel model;
+    const auto &tbt = model.getTransferBandwidthTable();
+    float max_bw = model.getMaxNoCTransferBandwidth();
+    for (size_t packet_size : {2048, 4096, 8192}) {
+        EXPECT_FLOAT_EQ(
+            interpolateBW(tbt, max_bw, packet_size, 1, SinglePacketBWModel::LatencyFloor),
+            interpolateBW(tbt, max_bw, packet_size, 1, SinglePacketBWModel::Legacy))
+            << "packet_size=" << packet_size;
+    }
+    // ... but sub-knee Wormhole packets do differ
+    EXPECT_LT(
+        interpolateBW(tbt, max_bw, 512, 1, SinglePacketBWModel::LatencyFloor),
+        interpolateBW(tbt, max_bw, 512, 1, SinglePacketBWModel::Legacy));
+}
+
+TEST(npeSinglePacketBWTest, ConfigDefaultsToLegacy) {
+    npeConfig cfg;
+    EXPECT_EQ(cfg.single_packet_bandwidth_model, "legacy");
+    EXPECT_EQ(cfg.getSinglePacketBWModel(), SinglePacketBWModel::Legacy);
+}
+
+TEST(npeSinglePacketBWTest, ConfigSelectsLatencyFloor) {
+    npeConfig cfg;
+    cfg.single_packet_bandwidth_model = "latency_floor";
+    EXPECT_EQ(cfg.getSinglePacketBWModel(), SinglePacketBWModel::LatencyFloor);
+    EXPECT_NO_THROW(npeAPI{cfg});
+}
+
+TEST(npeSinglePacketBWTest, ConfigRejectsUnknownModelName) {
+    npeConfig cfg;
+    cfg.single_packet_bandwidth_model = "not_a_model";
+    EXPECT_THROW(npeAPI{cfg}, npeException);
+}
+
+// End-to-end through updateTransferBandwidth(), which is what the device models call.
+TEST(npeSinglePacketBWTest, UpdateTransferBandwidthHonorsMode) {
+    auto make_transfer = [](uint32_t packet_size, uint32_t num_packets) {
+        npeWorkloadTransfer tr(
+            packet_size,
+            num_packets,
+            Coord{0, 1, 1},
+            Coord{0, 5, 5},
+            /*injection_rate=*/1e9f,
+            /*phase_cycle_offset=*/0,
+            nocType::NOC0);
+        return PETransferState(tr, 0, {});
+    };
+
+    std::vector<PETransferState> transfers = {make_transfer(16, 1), make_transfer(512, 1)};
+    std::vector<PETransferID> live = {0, 1};
+
+    updateTransferBandwidth(&transfers, live, kBlackholeTBT, kBlackholeMaxBW);
+    EXPECT_FLOAT_EQ(transfers[0].curr_bandwidth, kBlackholeMaxBW);
+    EXPECT_FLOAT_EQ(transfers[1].curr_bandwidth, kBlackholeMaxBW);
+
+    updateTransferBandwidth(
+        &transfers, live, kBlackholeTBT, kBlackholeMaxBW, SinglePacketBWModel::LatencyFloor);
+    EXPECT_FLOAT_EQ(transfers[0].curr_bandwidth, latencyFloorBW(16, 1));
+    EXPECT_FLOAT_EQ(transfers[1].curr_bandwidth, 24.2f);
+}
+
+}  // namespace tt_npe

--- a/tt_npe/py/pycli/tt_npe.py
+++ b/tt_npe/py/pycli/tt_npe.py
@@ -41,6 +41,17 @@ def parse_cli_args():
     )
 
     parser.add_argument(
+        "--single-packet-bw-model",
+        type=str,
+        default="legacy",
+        choices=["legacy", "latency_floor"],
+        help="How to model the bandwidth of single-packet (num_packets == 1) transfers. "
+        "'legacy' (default) models them at the device's peak bandwidth regardless of size; "
+        "'latency_floor' models them at the size-appropriate steady-state bandwidth from the "
+        "transfer bandwidth table. NOTE: 'latency_floor' changes predictions",
+    )
+
+    parser.add_argument(
         "-w", "--workload", type=str, default="", help="Run workload from JSON file"
     )
 
@@ -121,6 +132,7 @@ def main():
     cfg = npe.Config()
     cfg.device_name = args.device
     cfg.congestion_model_name = args.cong_model
+    cfg.single_packet_bandwidth_model = args.single_packet_bw_model
     cfg.workload_json_filepath = args.workload
     cfg.workload_is_noc_trace = args.workload_is_noc_trace
     cfg.cycles_per_timestep = args.cycles_per_timestep

--- a/tt_npe/py/pytest/test_bindings.py
+++ b/tt_npe/py/pytest/test_bindings.py
@@ -85,6 +85,96 @@ def test_npe_create_and_run_synthetic_workload():
     assert type(result) == npe.Stats
 
 
+def _single_transfer_cycles(packet_size, num_packets, mode, device="blackhole"):
+    """Run one isolated transfer and return the predicted cycle count."""
+    cfg = npe.Config()
+    cfg.device_name = device
+    cfg.single_packet_bandwidth_model = mode
+    # NOTE: keep cycles_per_timestep at the default-ish 32. The engine truncates
+    # `cycles_per_timestep * bandwidth` to an integer byte count, so a very small
+    # cycles_per_timestep combined with a sub-1-B/cycle bandwidth makes no forward
+    # progress. This is pre-existing engine behavior, reachable in "legacy" mode too.
+    cfg.cycles_per_timestep = 32
+    cfg.set_verbosity_level(0)
+
+    phase = npe.Phase()
+    phase.addTransfer(
+        npe.Transfer(
+            packet_size, num_packets, npe.Coord(0, 1, 1), npe.Coord(0, 5, 5), 0.0, 0, npe.NocType.NOC_0
+        )
+    )
+    wl = npe.Workload()
+    wl.addPhase(phase)
+    wl.setGoldenResultCycles({0: (0, 100), -1: (0, 100)})
+
+    npe_api = npe.InitAPI(cfg)
+    assert npe_api is not None
+    result = npe_api.runNPE(wl)
+    assert type(result) == npe.Stats
+    return result.per_device_stats[-1].estimated_cycles
+
+
+def test_npe_single_packet_bandwidth_model_defaults_to_legacy():
+    cfg = npe.Config()
+    assert cfg.single_packet_bandwidth_model == "legacy"
+
+
+def test_npe_single_packet_bandwidth_model_rejects_unknown_value():
+    cfg = npe.Config()
+    cfg.single_packet_bandwidth_model = "not_a_model"
+    assert npe.InitAPI(cfg) is None
+
+
+def test_npe_single_packet_bandwidth_model_accepts_latency_floor():
+    cfg = npe.Config()
+    cfg.single_packet_bandwidth_model = "latency_floor"
+    assert npe.InitAPI(cfg) is not None
+
+
+def test_npe_legacy_single_packet_bandwidth_is_size_independent():
+    # the defect: with num_packets == 1, legacy charges peak bandwidth for any packet
+    # size, so predicted cycles scale linearly with size (constant bandwidth). The exact
+    # bandwidth equality is asserted in the gtest; here it is only visible up to the
+    # engine's integer cycle quantization.
+    bw = {ps: ps / _single_transfer_cycles(ps, 1, "legacy") for ps in (256, 512, 1024)}
+    assert max(bw.values()) / min(bw.values()) < 1.2
+
+
+def test_npe_latency_floor_single_packet_is_size_dependent():
+    # under latency_floor each sub-knee single-packet transaction costs the same
+    # fixed number of cycles, so bandwidth scales with packet size
+    cycles = {ps: _single_transfer_cycles(ps, 1, "latency_floor") for ps in (16, 512, 1024)}
+    assert cycles[16] == cycles[512] == cycles[1024]
+    bw16 = 16 / cycles[16]
+    bw512 = 512 / cycles[512]
+    assert bw512 > bw16
+    assert 30.0 < bw512 / bw16 < 34.0  # ~32x, matching the 32x size ratio
+
+
+def test_npe_latency_floor_is_slower_than_legacy_for_small_single_packets():
+    for ps in (16, 128, 512):
+        assert _single_transfer_cycles(ps, 1, "latency_floor") > _single_transfer_cycles(
+            ps, 1, "legacy"
+        )
+
+
+def test_npe_multi_packet_transfers_are_unchanged_by_mode():
+    for ps in (16, 512, 2048):
+        for num_packets in (2, 4, 8):
+            assert _single_transfer_cycles(ps, num_packets, "legacy") == _single_transfer_cycles(
+                ps, num_packets, "latency_floor"
+            )
+
+
+def test_npe_wormhole_corpus_packet_sizes_are_unchanged_by_mode():
+    # the wormhole table is flat at its max from 2048B up, so both modes agree over the
+    # packet sizes the bundled noc trace corpus actually contains
+    for ps in (2048, 4096):
+        assert _single_transfer_cycles(
+            ps, 1, "legacy", device="wormhole_b0"
+        ) == _single_transfer_cycles(ps, 1, "latency_floor", device="wormhole_b0")
+
+
 def test_npe_create_and_run_larger_synthetic_workload():
 
     phase = npe.Phase()


### PR DESCRIPTION
## Problem

`interpolateBW()` (`tt_npe/cpp/include/npeDeviceModelUtils.hpp:16-50`) blends a "first packet at peak" term with a "steady state at table rate" term:

```cpp
float first_transfer_bw    = max_transfer_bw;                      // :31
float steady_state_ratio   = float(num_packets - 1) / num_packets; // :32
float first_transfer_ratio = 1.0 - steady_state_ratio;             // :33
float interpolated_bw =
    (first_transfer_ratio * first_transfer_bw) + (steady_state_ratio * steady_state_bw); // :36
```

At **`num_packets == 1`** this degenerates: `steady_state_ratio = 0`, `first_transfer_ratio = 1.0`, so the function returns `max_transfer_bw` for **any** packet size. The interpolation it just computed is discarded.

The blend is sensible for a multi-packet burst. It is wrong for a lone packet, where the whole transfer *is* the first packet.

**This is not a corner case — it is the only path the noc-trace ingest takes.** `convertNocTracesToNpeWorkload()` emits every NoC event with `num_packets` hardcoded to `1` and `packet_size = num_bytes` (`tt_npe/cpp/src/npeWorkloadIngest.cpp:643` for the unicast path, and `:606` / `:625` for the fabric-route path). That hardcoding is *correct* — a single `noc_async_read` of N bytes genuinely is one NoC transaction — but it means the transfer bandwidth table is bypassed entirely for trace-driven runs, which is tt-npe's primary mode. Every transfer runs at `min(injection_rate, max_transfer_bw)`.

**Observed on `main`** (Blackhole, one isolated transfer, `num_packets=1`, `cycles_per_timestep=32`):

| packet size | predicted cycles | implied B/cycle |
|---|---|---|
| 16 B | 1 | 16.0 (1-cycle floor; modelled bw is 60.9) |
| 512 B | 9 | 56.9 |
| 1024 B | 17 | 60.2 |
| 8192 B | 135 | 60.7 |
| 16384 B | 270 | 60.7 |

Expected: a 16 B transaction should not be modelled at the same bandwidth as an 8 KB one.

## Why the fix is principled

The tables are linear through the origin below the knee:

- Blackhole (`device_models/blackhole.hpp:477-478`): `{0,0},{128,6.0},{256,12.1},{512,24.2},{1024,48.0},{2048,57.7},{4096,58.7},{8192,60.4},{16384,60.9}`
- Wormhole (`device_models/wormhole_b0.hpp:464-465`): `{0,0},{128,5.5},{256,10.1},{512,18.0},{1024,27.4},{2048,30.0},{8192,30.0}`

So `packet_size / steady_state_bw` — the modelled cost of one transaction, in cycles — is a **constant** below the knee:

| size | BH table B/cyc | **BH cyc/txn** | BH legacy cyc/txn | WH table B/cyc | **WH cyc/txn** |
|---|---|---|---|---|---|
| 16 | 0.75 | **21.33** | 0.263 | 0.6875 | **23.27** |
| 32 | 1.50 | **21.33** | 0.525 | 1.375 | **23.27** |
| 64 | 3.00 | **21.33** | 1.051 | 2.75 | **23.27** |
| 128 | 6.00 | **21.33** | 2.102 | 5.50 | **23.27** |
| 256 | 12.10 | **21.16** | 4.204 | 10.10 | 25.35 |
| 512 | 24.20 | **21.16** | 8.407 | 18.00 | 28.44 |
| 1024 | 48.00 | **21.33** | 16.814 | 27.40 | 37.37 |
| 2048 | 57.70 | 35.49 (knee) | 33.629 | 30.00 | 68.27 (knee) |

On Blackhole that is **21.16–21.33 cycles per transaction across a 64× size range** (1 B .. 1024 B) — a 0.8 % spread. That constant is a **fixed per-transaction latency floor**, which is physically right: small NoC transactions are latency-bound, not bandwidth-bound. The table already encodes it; `num_packets == 1` is the only thing bypassing it.

**Honest qualification on Wormhole:** the constant-floor reading is exact only up to 128 B (23.27 cyc). The WH table bends earlier (25.3 cyc at 256 B, 28.4 at 512 B, 37.4 at 1024 B), so on WH this is "a floor plus a size term", not a clean floor. The fix is the same either way — use the table rate — but the "constant latency floor" framing is a Blackhole observation, not a universal one.

### Consequence: the model can now see coalescing

Under `legacy`, every single-packet transaction is charged `packet_size / 60.9` cycles, so moving a fixed payload as 16 B chunks and as 512 B chunks costs the *same total transaction time* — the model is structurally blind to transaction-size coalescing. Under `latency_floor` both chunk sizes cost ~21.2 cycles per transaction, so 32× fewer transactions is ~32× less modelled transaction time.

**Negative result, stated plainly:** this only shows up end-to-end when the NoC transaction is on the critical path. A synthetic Blackhole workload issuing 65536 B from one core as N simultaneous single-packet transfers shows both modes agreeing, because the NIU congestion term already binds:

| chunk | n transfers | legacy cycles | latency_floor cycles |
|---|---|---|---|
| 16 B | 4096 | 65505 | 65526 |
| 512 B | 128 | 2033 | 2038 |

So the coalescing claim above is about the **per-transaction cost** that `interpolateBW` controls, not a claim that every workload's predicted cycles change.

## Change

For `num_packets == 1`, return `steady_state_bw` instead of applying the blend. Five lines plus a comment; the `num_packets > 1` path is untouched.

I considered reformulating the blend instead — e.g. `time(N,S) = L + (N-1)*S/max_bw` with `L = S/steady_state_bw`, which reduces to `steady_state_bw` at N=1 and converges to `max_bw` as N→∞. It is more coherent, but it changes every multi-packet prediction, in the *opposite* direction from today's formula, and there is no golden data to validate that with (the noc-trace path never produces `num_packets > 1`, and there is no multi-packet corpus). So this takes the smaller change and leaves the N>1 blend exactly as it is. See Limitations.

### Back-compat: opt-in flag, default off

`npeConfig::single_packet_bandwidth_model`:

| mode | behavior |
|---|---|
| `legacy` **(default)** | bit-identical to today |
| `latency_floor` | single packets use the size-appropriate table rate |

Threaded through `interpolateBW` / `updateTransferBandwidth` / `npeDeviceModel::computeCurrentTransferRate` (all four device models — the two multichip models compose rather than inherit and carry duplicated code), with defaulted parameters so no existing caller changes behavior. Exposed via pybind (`cfg.single_packet_bandwidth_model`) and the CLI (`--single-packet-bw-model {legacy,latency_floor}`). Unknown values are rejected in `validateConfig()`.

Default is `legacy` deliberately: the change moves predictions, and the floor's absolute value is inherited from an existing unvalidated table (see Limitations).

## Reproduce

```bash
./build-npe.sh
source ENV_SETUP
python3 install/bin/tt_npe.py -w tt_npe/workload/noc_trace_json/2x2_BLOCK_TO_4x4_BLOCK.json \
    -t -d blackhole --single-packet-bw-model latency_floor -v
```

The degeneration itself, without a build, is `interpolateBW(tbt, 60.9, packet_size, 1)` for any `packet_size` — it returns `60.9`. `npeSinglePacketBWTest.LegacySinglePacketIsSizeIndependent` asserts exactly this.

## Validation

**Back-compat (the important one).** Built `main` (stashed the branch, rebuilt), ran all 71 bundled traces, then restored the branch, rebuilt, and re-ran in `legacy`. Compared 5 numeric columns per trace = 355 cells per arch:

- Blackhole: `main` vs branch/`legacy` → **0 / 355 differing cells**
- Wormhole: `main` vs branch/`legacy` → **0 / 355 differing cells**

Unit suites on the `main` build: 45/45 gtest. On the branch: **58/58 gtest, 18/18 pytest**, both run from `tt_npe/` (running gtest from the repo root gives 2 pre-existing cwd-relative failures unrelated to this change). Clean build (`rm -rf build install && ./build-npe.sh`) with no new warnings.

**Effect on the bundled corpus — and why it is not a validation.** The corpus contains **only 2048 B and 4096 B payloads** (13824 events at 2048 B, 5248 at 4096 B, plus 6196 zero-byte non-transfer events). Both are **at or above the knee**, precisely the regime where the fix is designed to do nothing. So the corpus is back-compat evidence, not evidence that the fix is correct:

| arch | mode | mean \|err\| | median | p90 | worst | traces changed |
|---|---|---|---|---|---|---|
| Wormhole | legacy | 3.17 % | 2.27 % | 6.53 % | 12.73 % | — |
| Wormhole | latency_floor | 3.17 % | 2.27 % | 6.53 % | 12.73 % | **0 / 71** |
| Blackhole | legacy | 28.16 % | 39.23 % | 46.41 % | 60.95 % | — |
| Blackhole | latency_floor | 28.15 % | 39.23 % | 46.41 % | 60.93 % | 40 / 71 |

Wormhole is **exactly unchanged** (0/355 cells) because the WH table is flat at 30.0 from 2048 B up and `max_transfer_bw` is also 30.0, so `steady_state_bw == max_transfer_bw` over the whole corpus. Blackhole moves microscopically (57.7 / 58.7 vs 60.9 → 4–5 % bandwidth) with 151/355 cells changed; per-trace `estimated_cycles` deltas range −1.31 % to +1.48 %.

Two caveats on that Blackhole row: (a) the bundled traces were recorded on Wormhole (WH mean error 3.2 %, BH 28.2 %), so running them against the Blackhole model is a cross-arch what-if, not a Blackhole accuracy measurement; (b) some deltas are *negative* — slowing a transfer changes timestep quantization and transfer overlap, and `estimated_cycles` is a max over transfer end cycles, so `latency_floor` is not a pure slowdown.

**Where it matters — sub-knee.** Blackhole, one isolated transfer, `num_packets=1`, `cycles_per_timestep=32`:

| packet size | legacy cycles | latency_floor cycles | legacy B/cyc | latency_floor B/cyc |
|---|---|---|---|---|
| 16 | 1 | **22** | 16.00 | 0.73 |
| 32 | 1 | **22** | 32.00 | 1.45 |
| 128 | 3 | **22** | 42.67 | 5.82 |
| 512 | 9 | **22** | 56.89 | 23.27 |
| 1024 | 17 | **22** | 60.24 | 46.55 |
| 2048 | 34 | 36 | 60.24 | 56.89 |
| 4096 | 68 | 70 | 60.24 | 58.51 |
| 16384 | 270 | 270 | 60.68 | 60.68 |

The flat 22-cycle column for every size ≤ 1024 B is the latency floor (21.16–21.33, rounded up by the engine). 16 B and 512 B are no longer modelled at the same bandwidth — the ratio is now 32×, matching the size ratio.

Multi-packet is unchanged in both modes (verified for `packet_size ∈ {16, 512, 2048}` × `num_packets ∈ {2, 4, 8}`: identical cycle counts).

**Tests:** 13 gtest in `tt_npe/cpp/test/test_npe_single_packet_bw.cpp` + 8 pytest in `tt_npe/py/pytest/test_bindings.py`, covering: the defaulted argument is `legacy`; legacy single-packet bandwidth is size-independent (the defect, asserted exactly); `latency_floor` is size-dependent and monotone; the sub-knee cyc/txn constant; the 16 B vs 512 B ratio; multi-packet identical across modes; above-table sizes identical across modes; the Wormhole corpus sizes identical across modes; config default, validation, and rejection of unknown values; and `updateTransferBandwidth()` end-to-end. The test file also asserts its hardcoded copy of the Blackhole table matches `BlackholeDeviceModel`'s, so the arithmetic above cannot silently drift.

## Limitations — please read

1. **The latency floor's absolute value is inherited, not silicon-validated here.** ~21.3 cycles (BH) / ~23.3 cycles (WH) comes entirely from extrapolating the existing `TransferBandwidthTable` to small sizes. I have not measured single-transaction NoC latency on silicon and this PR makes no claim about that number's accuracy. The change is that the model *uses the table it already has* instead of discarding it; if the table's small-packet region is wrong, `latency_floor` is wrong in exactly the same way. Calibrating it needs a silicon sweep of single `noc_async_read` latency vs size.

2. **The bundled corpus cannot validate the sub-knee regime.** It has no packets below 2048 B — nothing below the knee at all, let alone below 512 B. Every sub-knee number above is model output, not a prediction checked against hardware. The corpus results are offered as *back-compat* evidence only.

3. **The `num_packets > 1` blend is left untouched and is arguably also wrong.** As written, larger bursts get *lower* modelled bandwidth (weight `(N-1)/N` on the smaller `steady_state_bw`, converging down to it as N→∞), which is backwards from pipelining intuition. Not changed here because there is no data to validate a replacement and it would move far more predictions. Worth a separate look.

4. **`latency_floor` makes an existing engine stall easier to reach.** `npeEngine.cpp:293` computes `size_t max_transferrable_bytes = cycles_active_in_curr_timestep * lt.curr_bandwidth`, truncating to an integer byte count. If `cycles_per_timestep * bandwidth < 1` the transfer makes no progress and the sim spins toward `MAX_CYCLE_LIMIT` (5e10). This is **pre-existing** — reproduced on `main` in `legacy` mode with `packet_size=16, num_packets=1000, cycles_per_timestep=1` (bandwidth 0.81 B/cyc) — but `latency_floor` reaches sub-1-B/cycle bandwidths without needing an extreme `num_packets`. At the `cycles_per_timestep=32` used by the CLI default and by `npe_analyze_noc_trace_dir.py` it is unreachable (worst case `32 × 6.0/128 = 1.5` bytes/timestep on BH, `1.375` on WH), so no shipped entry point is affected. Not fixed here to keep the change scoped; a `std::max(1, ...)` or a fractional-byte accumulator would be the fix.

5. **The corpus is Wormhole-recorded.** Blackhole numbers in this PR are the WH traces replayed through the BH model, useful only as a "does anything move" signal.

6. Timestep quantization means the end-to-end cycle counts in the sub-knee table are rounded (21.33 → 22); the exact bandwidths are asserted in the gtest, not inferred from cycle counts.

Also noticed but left alone (pre-existing on `main`, unrelated): `install/bin/programmatic_workload_generation.py` aborts with `boost::wrapexcept<std::out_of_range>` because it never calls `setGoldenResultCycles()`, and `tt_npe.py` crashes after a successful sim on `result.wallclock_runtime_us` (that one is #126).

## Motivation

We generate data-movement kernels in tt-dm-codegen and are chasing losses on sharded/strided writers. Transaction-size coalescing is one of the main levers available, and we want to A/B it offline on CPU with tt-npe instead of burning device-exclusive sweeps. With `num_packets == 1` returning peak bandwidth for every size, the model cannot express that lever at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Merge order:** #126, #128, #129 and #130 are mutually independent — verified by building their union (62/62 gtest, 23/23 pytest, and bit-identical to `main` at default settings across all 71 bundled traces). They can land in any order.

#125 is the only one that conflicts (with #128 on the `deviceStats` pickle tuple, and with #130 on the congestion hook), so **please merge #125 last** — I'll rebase it once the others land.
