### PR TITLE
Fix mesh golden cycle underflow when no golden data is present

### DIFF
--- a/tt_npe/cpp/include/npeWorkload.hpp
+++ b/tt_npe/cpp/include/npeWorkload.hpp
@@ -112,7 +112,17 @@ class npeWorkload {
     boost::unordered_flat_map<DeviceID, std::pair<Cycle, Cycle>> getGoldenResultCycles() const { return golden_cycles; }
     void setGoldenResultCycles(boost::unordered_flat_map<DeviceID, std::pair<Cycle, Cycle>> golden_cycles) {
         this->golden_cycles = golden_cycles;
-        
+
+        // No per-device golden data means no mesh-wide range either. Without
+        // this the loop below never runs, the sentinels survive as
+        // {Cycle::max(), 0}, and npeStats' golden_end - golden_start underflows
+        // to 1 -- which then passes its `golden_cycles > 0` guard and is
+        // reported as a measured cycle count.
+        if (golden_cycles.empty()) {
+            this->golden_cycles[MESH_DEVICE] = {0, 0};
+            return;
+        }
+
         // Set golden cycles for entire mesh
         Cycle golden_start = std::numeric_limits<Cycle>::max();
         Cycle golden_end = 0;

--- a/tt_npe/cpp/test/test_npe_workload.cpp
+++ b/tt_npe/cpp/test/test_npe_workload.cpp
@@ -12,6 +12,22 @@
 
 namespace tt_npe {
 
+// An empty golden map leaves the mesh-wide range at its sentinel initial
+// values: golden_start stays at Cycle::max() and golden_end at 0. Cycle is
+// uint64_t, so npeStats computes golden_end - golden_start and underflows to
+// 1 -- which passes the `golden_cycles > 0` guard and is reported as a real
+// measurement.
+TEST(npeWorkloadTest, EmptyGoldenResultCyclesDoNotProduceASentinelMeshRange) {
+    tt_npe::npeWorkload wl;
+    wl.setGoldenResultCycles({});
+
+    auto [golden_start, golden_end] = wl.getGoldenResultCycles(MESH_DEVICE);
+    EXPECT_LE(golden_start, golden_end)
+        << "mesh golden range is inverted: start=" << golden_start << " end=" << golden_end;
+    EXPECT_EQ(golden_end - golden_start, 0u)
+        << "mesh golden cycle count underflowed to " << (golden_end - golden_start);
+}
+
 TEST(npeWorkloadTest, CanConstructWorkload) {
     tt_npe::npeWorkload wl;
     tt_npe::npeWorkloadPhase phase;


### PR DESCRIPTION
## The bug

`setGoldenResultCycles` builds the mesh-wide golden range by narrowing `golden_start` down from `Cycle::max()` and `golden_end` up from `0`:

```cpp
Cycle golden_start = std::numeric_limits<Cycle>::max();
Cycle golden_end = 0;
for (const auto &[device_id, device_golden_cycles] : golden_cycles) { ... }
this->golden_cycles[MESH_DEVICE] = {golden_start, golden_end};
```

When the per-device map is **empty** the loop never runs, both sentinels survive, and `MESH_DEVICE` is recorded as `{Cycle::max(), 0}` — an inverted range.

`npeStats::finishSimulation` then does `golden_end - golden_start`. `Cycle` is `uint64_t`, so this **underflows to 1**, not 0.

That number is worse than a zero would be:

- `1 > 0`, so it passes the `if (golden_cycles > 0)` guard in `deviceStats::to_string` — the guard that exists precisely to suppress the no-golden-data case
- `cycle_prediction_error` is computed against it. A 100-cycle estimate is reported as **9900%**
- The value is exposed to Python via the `cycle_prediction_error` binding, so consumers read it too

So instead of "no golden data", you get a plausible-looking measurement.

## The fix

An empty map means there is no mesh-wide range to report. Record `{0, 0}` and return before the narrowing loop; the guard in `to_string` then does what it was written to do.

## Test

`EmptyGoldenResultCyclesDoNotProduceASentinelMeshRange` asserts the range is not inverted and the derived count is 0. Against the current code it fails with:

```
mesh golden cycle count underflowed to 1
```

Full suite: **46 passed, 0 failed** (45 before this change).

## Build note, unrelated to this patch

Worth flagging separately: `CMakeLists.txt` adds `-mavx2` unconditionally. On a CPU without AVX2 the build succeeds and `tt_npe_ut` then dies with a bare `Illegal instruction` and no diagnostic — I hit this on a Xeon E5-2670 (Sandy Bridge), which has AVX but not AVX2. Rebuilding with `-mavx` made all tests pass, so nothing else was wrong.

Every GitHub Actions runner has AVX2, which is why CI never sees it, and the README documents no CPU requirement. A CMake option or a documented prerequisite would turn a confusing crash into a clear message. Happy to send that as its own PR if you'd like it — I kept it out of this one, and this branch does not touch `CMakeLists.txt`.

I built with g++ 12 rather than the Clang 17/20 the CMake defaults to, since that is what was available.